### PR TITLE
Add Keystone v3 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 python-keystoneclient
 python-heatclient
+six
 celery
 -e git+https://github.com/edx/xblock-utils.git@213a97a50276d6a2504d8133650b2930ead357a0#egg=xblock-utils
 -e .


### PR DESCRIPTION
This adds optional Keystone v3 support.  It tries to detect which
version (v2 or v3) is supported by the cloud, and uses the appropriate
one.

It is fully backwards-compatible with previous XBlock definitions.