### PR TITLE
Improved idle detection and UI

### DIFF
--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -331,6 +331,7 @@ class HastexoXBlock(StudioEditableXBlockMixin, XBlock):
 
         # Add the public CSS and JS
         frag.add_css_url(self.runtime.local_resource_url(self, 'public/css/main.css'))
+        frag.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/plugins.js'))
         frag.add_javascript_url(self.runtime.local_resource_url(self, 'public/js/main.js'))
 
         # Choose the JS initialization function

--- a/hastexo/public/css/main.css
+++ b/hastexo/public/css/main.css
@@ -1,14 +1,6 @@
-.pending, .error, .check_button, .check_pending, .check_complete, .check_error {
-    position: relative;
-    margin: 0 auto;
-}
-
-.error, .check_button, .check_pending, .check_complete, .check_error {
+p.check {
     display: none;
-}
-
-.check_pass, .check_total {
-    font-weight: bold;
+    text-align: right;
 }
 
 #gateonecontainer {
@@ -31,4 +23,106 @@
 #container {
     height: 100%;
     width: 100%
+}
+
+.dialog-overlay {
+    position: fixed;
+    top: 0; right: 0; bottom: 0; left: 0;
+    width: 100%; height: 100%;
+    overflow: auto;
+    padding: 20px;
+    box-sizing: border-box;
+    background: radial-gradient(circle at 50% 50%, rgba(0,0,0,0.4), rgba(0,0,0,0.6));
+    text-align: center;
+    z-index: 1001;
+}
+
+.dialog-overlay:before {
+    content: "";
+    display: inline-block;
+    height: 100%;
+    vertical-align: middle;
+    margin-right: -0.05em;
+}
+
+.dialog {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1002;
+    max-width: 480px;
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px #000;
+    text-align: left;
+}
+
+.dialog .inner {
+    background: rgb(245, 245, 245);
+    border-radius: 0;
+    border: 1px solid rgba(0, 0, 0, 0.9);
+    box-shadow: inset 0 1px 0 0 rgba(255, 255, 255, 0.7);
+    overflow: hidden;
+    padding: 10px;
+    position: relative;
+}
+
+.dialog h1,
+.dialog p {
+    text-align: center;
+}
+
+.dialog h1 {
+    margin-bottom: 20px;
+}
+
+.dialog {
+    display: none;
+}
+
+.dialog .loader:before,
+.dialog .loader:after,
+.dialog .loader {
+    display: inline-block;
+    border-radius: 50%;
+    width: 2.5em;
+    height: 2.5em;
+    animation-fill-mode: both;
+    animation: ellipsis 1.8s infinite ease-in-out;
+}
+
+.dialog .loader {
+    font-size: 2px;
+    margin: 10px 0 4px 16px;
+    position: relative;
+    animation-delay: -0.16s;
+}
+
+.dialog .loader:before {
+    left: -6em;
+    animation-delay: -0.32s;
+}
+
+.dialog .loader:after {
+    left: 6em;
+}
+
+.dialog .loader:before,
+.dialog .loader:after {
+    content: '';
+    position: absolute;
+    top: 0;
+}
+
+@keyframes ellipsis {
+    0%,
+    80%,
+    100% {
+        box-shadow: 0 2.5em 0 -1.3em #000;
+    }
+    40% {
+        box-shadow: 0 2.5em 0 0 #000;
+    }
 }

--- a/hastexo/public/js/plugins.js
+++ b/hastexo/public/js/plugins.js
@@ -1,0 +1,94 @@
+/* A cached version of jQuery's getScript. */
+jQuery.cachedScript = function(url, options) {
+    options = $.extend( options || {}, {
+        dataType: "script",
+        cache: true,
+        url: url
+    });
+
+    return jQuery.ajax(options);
+};
+
+/* A very, very simple jQuery dialog.    Based on
+ * http://github.com/kylefox/jquery-modal. */
+(function($) {
+    var current = null;
+
+    $.dialog = function(el, options) {
+        $.dialog.close();
+        var remove, target;
+        this.$body = $('body');
+        this.options = $.extend({}, $.dialog.defaults, options);
+        this.$elm = el;
+        this.$body.append(this.$elm);
+        this.open();
+    };
+
+    $.dialog.prototype = {
+        constructor: $.dialog,
+
+        open: function() {
+            var m = this;
+            this.block();
+            this.show();
+        },
+
+        close: function() {
+            this.unblock();
+            this.hide();
+        },
+
+        block: function() {
+            this.overlay = $('<div class="dialog-overlay"></div>');
+            this.$body.css('overflow','hidden');
+            this.$body.append(this.overlay);
+        },
+
+        unblock: function() {
+            this.overlay.children().appendTo(this.$body);
+            this.overlay.remove();
+            this.$body.css('overflow','');
+        },
+
+        show: function() {
+            this.$elm.addClass(this.options.dialogClass + ' current');
+            this.$elm.appendTo(this.overlay);
+            this.$elm.show();
+        },
+
+        hide: function() {
+            this.$elm.removeClass('current');
+            var _this = this;
+            this.$elm.hide(0);
+        },
+    };
+
+    $.dialog.close = function(event) {
+        if (!current)
+            return;
+
+        if (event)
+            event.preventDefault();
+
+        current.close();
+        var that = current.$elm;
+        current = null;
+        return that;
+    };
+
+    /* Returns if there currently is an active dialog. */
+    $.dialog.isActive = function () {
+        return current ? true : false;
+    }
+
+    $.dialog.defaults = {
+        dialogClass: 'dialog'
+    };
+
+    $.fn.dialog = function(options){
+        if (this.length === 1) {
+            current = new $.dialog(this, options);
+        }
+        return this;
+    };
+})(jQuery);

--- a/hastexo/static/html/main.html
+++ b/hastexo/static/html/main.html
@@ -1,27 +1,62 @@
 <div class="hastexo_block">
-  <div class="pending">
-    <p>Please wait while we prepare your lab environment...</p>
-  </div>
-  <div class="error">
-    <p>There was a problem preparing your lab environment:</p>
-    <p class="error_msg"></p>
-  </div>
-  <div class="check_button">
-    <input type="button" value="Check progress" class="check"></input>
-  </div>
-  <div class="check_pending">
-    <p>Checking...</p>
-  </div>
-  <div class="check_complete">
-    <p>You scored <span class="check_pass">0</span> out of <span class="check_total">0</span>.</p>
-  </div>
-  <div class="check_error">
-    <p>There was a problem checking your progress:</p>
-    <p class="check_error_msg"></p>
-  </div>
   <div id="gateonecontainer">
     <div id="gateone">
       <div id="container" class="terminal" />
+    </div>
+  </div>
+  <p class="check"><input type="button" value="Check progress"></input></p>
+  <div class="dialog" id="launch_pending">
+    <div class="inner">
+      <h1><span>Please wait</span><span class="loader"></span></h1>
+      <p class="message">We are connecting you to your lab environment.</p>
+      <p class="message">If this is the first time, be patient: it may take a couple of <strong>minutes</strong> to provision your stack.</p>
+    </div>
+  </div>
+  <div class="dialog" id="launch_error">
+    <div class="inner">
+      <h1>Whoops!</h1>
+      <p class="message">There was a problem connecting to your lab environment, and this is what the server told us:</p>
+      <p class="error_msg"></p>
+      <p class="buttons">
+        <input type="button" class="ok" value="Ok"></input>
+        <input type="button" class="retry" value="Retry"></input>
+      </p>
+    </div>
+  </div>
+  <div class="dialog" id="check_pending">
+    <div class="inner">
+      <h1><span>Please wait</span><span class="loader"></span></h1>
+      <p class="message">While we check your progress.  It shouldn't take more than a few <strong>seconds</strong>.</p>
+    </div>
+  </div>
+  <div class="dialog" id="check_complete">
+    <div class="inner">
+      <h1>Done!</h1>
+      <p class="message">You successfully completed <strong class="check_pass">0</strong> out of <strong class="check_total">0</strong> assessment tests.</p>
+      <p class="buttons">
+        <input type="button" class="ok" value="Ok"></input>
+      </p>
+    </div>
+  </div>
+  <div class="dialog" id="check_error">
+    <div class="inner">
+      <h1>Whoops!</h1>
+      <p class="message">There was a problem checking your progress, and this is what the server told us:</p>
+      <p class="error_msg"></p>
+      <p class="buttons">
+        <input type="button" class="ok" value="Ok"></input>
+        <input type="button" class="retry" value="Retry"></input>
+      </p>
+    </div>
+  </div>
+  <div class="dialog" id="idle">
+    <div class="inner">
+      <h1>We think you're idle.</h1>
+      <p class="message">We have paused your lab environment.</p>
+      <p>If we're wrong or if you just came back, please click <strong>Ok</strong> to resume it.</p>
+      <p class="buttons">
+        <input type="button" class="ok" value="Ok"></input>
+      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Introduced here is idle detection based on keyboard input in the browser
terminal.  By default, if the user doesn't type anything in 10 minutes,
their stack will be suspended.  When that happens and their browser
window is showing the terminal unit, a modal dialog will be displayed:
resuming the stack will require clicking a button.

If the student navigates away from the lab unit but remains in the same
section, the idle and keepalive timers still run.  The result is that
their stack will be suspended only after the idle timer expires (as
opposed to when the shorter keepalive timer does).  This is intentional,
as it is better UX for the student to be have more time to return to the
lab unit and not need to have the stack be resumed.

The dialog itself is a new feature introduced here, and is also used in
interaction with the user elsewhere, such as during stack launch, or
running assessment tests.  An unintrusive, pure-CSS loading animation is
also included for situations where the student needs to wait.

This changeset also fixes a bug where the "Check progress" button would
disappear when navigating away and back to the lab unit.

Finally, there was some refactoring of the Javascript code:

* a new plugins.js file contains code used by, but not a direct part of,
  the XBlock (such as the dialog plugin).

* a few readability improvements in main.js