### PR TITLE
Lower keepalive timeout

### DIFF
--- a/hastexo/public/js/main.js
+++ b/hastexo/public/js/main.js
@@ -2,7 +2,7 @@ var stack, check;
 var status_timer, keepalive_timer, idle_timer, check_timer;
 var timeouts = {
     status: 10000,
-    keepalive: 60000,
+    keepalive: 15000,
     idle: 600000,
     check: 5000
 };


### PR DESCRIPTION
To lower the chance that a missed keepalive will result in a suspended
stack, increase keepalive frequency from once per minute to 4 times per
minute.