### PR TITLE
Handle task timeouts more robustly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='hastexo-xblock',
-    version='0.1.1',
+    version='0.1.2',
     description='hastexo XBlock',
     packages=[
         'hastexo',


### PR DESCRIPTION
Introduce code to handle a configurable task timeout (default = 10
minutes) at the highest possible level: during each browser request.

This should help handle corner cases where the task ID is not cleared
when a task never returns, thus making the XBlock think that a
particular stack is being launched forever.