### PR TITLE
Bump paramiko version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ python-heatclient==0.8.0
 markdown2==2.3.0
 six==1.10.0
 celery==3.1.18
-paramiko==1.9.0
+paramiko>=1.16.0
 -e git+https://github.com/edx/xblock-utils.git@v1.0.2#egg=xblock-utils==v1.0.2
 -e .

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
         'xblock-utils',
         'markdown2==2.3.0',
         'python-keystoneclient==2.0.0',
-        'python-heatclient==0.8.0'
+        'python-heatclient==0.8.0',
+        'paramiko>=1.16.0',
     ],
     entry_points={
         'xblock.v1': [


### PR DESCRIPTION
Bump to a paramiko version that supports connecting to the default
settings on newer openssh-server distro packages (such as on Ubuntu
16.04).