### PR TITLE
Introduce reboot on resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,21 @@ To ensure your Heat template has the required configuration:
         value: { get_attr: [ training_key, private_key ] }
     ```
 
+    If you also provide a list of servers under an `reboot_on_resume` item, the
+    servers listed therein will be hard rebooted after a resume operation:
+
+    ```
+      reboot_on_resume:
+        description: Servers to be rebooted after resume
+        value:
+          - { get_resource: server1 }
+          - { get_resource: server2 }
+    ```
+
+    (This is meant primarily as a workaround to resurrect servers that use
+    nested KVM, as the latter does not support a managed save and subsequent
+    restart.)
+
 4. Upload the Heat template to the content store and make a note of its static
    asset file name.
 

--- a/hastexo/nova.py
+++ b/hastexo/nova.py
@@ -1,0 +1,81 @@
+from keystoneauth1.identity import generic
+from keystoneauth1 import session as kssession
+from novaclient import client as nova_client
+
+
+class NovaWrapper(object):
+    """
+    A class that wraps the Compute service for the Hastexo XBlock.
+
+    """
+    os_options = (
+        'os_auth_url',
+        'os_auth_token',
+        'os_username',
+        'os_password',
+        'os_user_id',
+        'os_user_domain_id',
+        'os_user_domain_name',
+        'os_tenant_id',
+        'os_tenant_name',
+        'os_project_id',
+        'os_project_name',
+        'os_project_domain_id',
+        'os_project_domain_name',
+        'os_region_name'
+    )
+
+    options = {}
+
+    def __init__(self, **configuration):
+        self.service_type = 'compute'
+        self.endpoint_type = 'publicURL'
+        self.api_version = '2.0'
+
+        # Set OpenStack options
+        options = configuration.get("credentials")
+        for os_option in self.os_options:
+            self.options[os_option] = options.get(os_option)
+
+    def get_client(self):
+        keystone_session = kssession.Session(verify=True)
+        if self.options['os_auth_token']:
+            kwargs = {
+                'token': self.options['os_auth_token'],
+                'auth_url': self.options['os_auth_url']
+            }
+            keystone_auth = generic.Token(**kwargs)
+        else:
+            project_id = self.options['os_project_id'] or self.options['os_tenant_id']  # noqa: E501
+            project_name = self.options['os_project_name'] or self.options['os_tenant_name']  # noqa: E501
+            kwargs = {
+                'username': self.options['os_username'],
+                'user_id': self.options['os_user_id'],
+                'user_domain_id': self.options['os_user_domain_id'],
+                'user_domain_name': self.options['os_user_domain_name'],
+                'password': self.options['os_password'],
+                'auth_url': self.options['os_auth_url'],
+                'project_id': project_id,
+                'project_name': project_name,
+                'project_domain_id': self.options['os_project_domain_id'],
+                'project_domain_name': self.options['os_project_domain_name'],
+            }
+            keystone_auth = generic.Password(**kwargs)
+
+        return nova_client.Client(
+            self.api_version,
+            self.options['os_username'],
+            self.options['os_password'],
+            project_id=self.options['os_project_id'],
+            project_name=self.options['os_project_name'],
+            user_id=self.options['os_user_id'],
+            auth_url=self.options['os_auth_url'],
+            region_name=self.options['os_region_name'],
+            endpoint_type=self.endpoint_type,
+            service_type=self.service_type,
+            session=keystone_session,
+            auth=keystone_auth,
+            project_domain_id=self.options['os_project_domain_id'],
+            project_domain_name=self.options['os_project_domain_name'],
+            user_domain_id=self.options['os_user_domain_id'],
+            user_domain_name=self.options['os_user_domain_name'])

--- a/heat-templates/hot/openstack-sample.yaml
+++ b/heat-templates/hot/openstack-sample.yaml
@@ -419,3 +419,9 @@ outputs:
   private_key:
     description: Training private key
     value: { get_attr: [ training_key, private_key ] }
+  reboot_on_resume:
+    description: Servers to reboot upon resume
+    value:
+      - { get_resource: daisy }
+      - { get_resource: eric }
+      - { get_resource: frank }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ oslo.serialization==1.10.0
 keystoneauth1==2.18.0
 python-keystoneclient==3.10.0
 python-heatclient==1.6.1
-python-swiftclient==3.3.0
+python-novaclient==7.1.2
 paramiko==2.1.2
 celery==3.1.18
 -e git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==v1.0.5

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         'keystoneauth1==2.18.0',
         'python-keystoneclient==3.10.0',
         'python-heatclient==1.6.1',
-        'python-swiftclient==3.3.0',
+        'python-novaclient==7.1.2',
         'paramiko==2.1.2',
     ],
     entry_points={

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -107,6 +107,7 @@ class TestHastexoTasks(TestCase):
             mock_verify_stack.assert_called_with(
                 self.configuration,
                 self.stacks['CREATE_COMPLETE'],
+                False,
                 self.stack_name,
                 self.stack_user
             )
@@ -152,6 +153,7 @@ class TestHastexoTasks(TestCase):
             mock_verify_stack.assert_called_with(
                 self.configuration,
                 self.stacks['CREATE_COMPLETE'],
+                False,
                 self.stack_name,
                 self.stack_user
             )
@@ -194,6 +196,7 @@ class TestHastexoTasks(TestCase):
             mock_verify_stack.assert_called_with(
                 self.configuration,
                 self.stacks['CREATE_COMPLETE'],
+                False,
                 self.stack_name,
                 self.stack_user
             )
@@ -232,6 +235,7 @@ class TestHastexoTasks(TestCase):
             mock_verify_stack.assert_called_with(
                 self.configuration,
                 self.stacks['RESUME_COMPLETE'],
+                True,
                 self.stack_name,
                 self.stack_user
             )
@@ -271,6 +275,7 @@ class TestHastexoTasks(TestCase):
             mock_verify_stack.assert_called_with(
                 self.configuration,
                 self.stacks['RESUME_COMPLETE'],
+                True,
                 self.stack_name,
                 self.stack_user
             )


### PR DESCRIPTION
As a means of working around the inability of resuming a server with
nested KVM, allow the course author to specify a Heat template output
containing a list of servers that should be hard-rebooted whenever the
stack is automatically resumed.