### PR TITLE
Enable instructors to grab a learner's session

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+Unreleased
+-------------------------
+* [Enhancement] Enable `show_in_read_only_mode` XBlock attribute
+  to allow instuctors to use this XBlock while masquerading
+  as a specific learner.
+
 Version 7.12.0 (2024-08-06)
 -------------------------
 * [Enhancement] Add support for the Open edX Redwood release.

--- a/README.md
+++ b/README.md
@@ -657,6 +657,14 @@ as usual, with the child element referring to it by URL name:
 
 Child blocks will always be rendered _above_ the terminal.
 
+### Using the hastexo XBlock while masquerading as a specific learner
+
+Instructors can use the hastexo XBlock lab environments when masquerading as a specific learner by using the "View this course as:" option in the LMS staff header.
+
+The learner will not know when an instructor is using their lab, so we advise to be mindful of the changes you make while the learner is active at the same lab.
+
+This feature should be considered experimental, and is subject to future change or removal.
+
 ## Student experience
 
 When students navigate to a unit with a hastexo XBlock in it, a new Heat

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -268,6 +268,7 @@ class HastexoXBlock(XBlock,
     has_children = True
     icon_class = 'problem'
     block_settings_key = SETTINGS_KEY
+    show_in_read_only_mode = True
 
     def parse_attributes(tag, node, block):
         """


### PR DESCRIPTION
For a while now, we've wanted to provide instructors with a way to take over, or share, a learner's session. We might just be able to do so by simply adding the `show_in_read_only_mode` attribute to the XBlock.

`show_in_read_only_mode` is an attribute that is `False` by default, and means that when an instructor is masquerading (that is, using the LMS with "View this course as: Specific learner" option), the XBlock is replaced by the text "This type of component cannot be shown while viewing the course as a specific student" (in lms/djangoapps/courseware/masquerade.py):

```python
def filter_displayed_blocks(block, unused_view, frag, unused_context):
    """
    A wrapper to only show XBlocks that set `show_in_read_only_mode` when masquerading as a specific user.

    We don't want to modify the state of the user we are masquerading as, so we can't show XBlocks
    that store information outside of the XBlock fields API.
    """
    if getattr(block, 'show_in_read_only_mode', False):
        return frag
    return Fragment(
        _(u'This type of component cannot be shown while viewing the course as a specific student.')
    )
```

Now the first thing we'd need to thus do is to set `show_in_read_only_mode` to `True`, so that the XBlock is rendered even when masquerading.

I **think** (or I hope) that by pointing the instructor's browser at the same Guacamole session as the learner, they'll both be able to interact with the learner's terminal. The devil may very much be in the details. For example, the learner's session might be cut off the moment the instructor connects to it.

Even if so, that may be something that is worth accepting, because the instructor could temporarily take over the learner's session, and when they're done, the learner could just refresh the page. Later on, we could figure out how to actually make the session shareable (if that's even possible).

In addition, making the attribute a read-only property on the XBlock is just a first stab — arguably, it would be smart to make this configurable for course authors.