### PR TITLE
Hawthorn compatibility updates (including XBlock 1.2 testing)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Version 2.4.0 (2018-08-21)
+---------------------------
+
+* [Enhancement] Hawthorn compatibility updates
+
 Version 2.3.3 (2018-08-01)
 ---------------------------
 

--- a/guacamole/install.sh
+++ b/guacamole/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 GUACAMOLE_VERSION="0.9.13"
-HASTEXO_VERSION="2.3.3"
+HASTEXO_VERSION="2.4.0"
 
 # Install requirements
 apt update

--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.hastexo.xblock</groupId>
     <artifactId>hastexo-xblock</artifactId>
     <packaging>war</packaging>
-    <version>2.3.3</version>
+    <version>2.4.0</version>
     <name>hastexo-xblock</name>
     <url>http://github.com/hastexo/hastexo-xblock/</url>
 

--- a/hastexo/__init__.py
+++ b/hastexo/__init__.py
@@ -1,1 +1,0 @@
-from .hastexo import HastexoXBlock  # noqa: F401

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -86,7 +86,7 @@ class HastexoXBlock(XBlock,
         scope=Scope.user_state,
         help="The check task id")
     check_timestamp = Integer(
-        default="",
+        default=None,
         scope=Scope.user_state,
         help="When the check task was launched")
     check_status = Dict(

--- a/hastexo/models.py
+++ b/hastexo/models.py
@@ -7,6 +7,7 @@ class StackCommon(models.Model):
 
     """
     class Meta:
+        app_label = 'hastexo'
         abstract = True
 
     name = models.CharField(max_length=64, db_index=True)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def package_data(pkg, roots):
 
 setup(
     name='hastexo-xblock',
-    version='2.3.3',
+    version='2.4.0',
     description='hastexo XBlock: '
                 'Makes arbitrarily complex lab environments '
                 'available on an Open edX LMS',

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     ],
     entry_points={
         'xblock.v1': [
-            'hastexo = hastexo:HastexoXBlock',
+            'hastexo = hastexo.hastexo:HastexoXBlock',
         ]
     },
     scripts=package_scripts(["bin"]),

--- a/tests/unit/test_hastexo.py
+++ b/tests/unit/test_hastexo.py
@@ -1,6 +1,8 @@
 import time
 import json
-import hastexo
+from hastexo.hastexo import HastexoXBlock
+from hastexo.models import Stack
+from hastexo.utils import DEFAULT_SETTINGS
 
 from mock import Mock, patch, DEFAULT
 from webob import Request
@@ -60,9 +62,9 @@ class TestHastexoXBlock(TestCase):
         usage_id = runtime.id_generator.create_usage(def_id)
         scope_ids = ScopeIds('user', block_type, def_id, usage_id)
 
-        self.block = hastexo.HastexoXBlock(runtime,
-                                           field_data,
-                                           scope_ids=scope_ids)
+        self.block = HastexoXBlock(runtime,
+                                   field_data,
+                                   scope_ids=scope_ids)
 
     def test_get_configuration(self):
         """
@@ -107,7 +109,7 @@ class TestHastexoXBlock(TestCase):
         timedelta = timezone.timedelta(seconds=suspend_timeout)
         suspend_timestamp = timezone.now() - timedelta
         course_id, student_id = self.block.get_block_ids()
-        stack, _ = hastexo.models.Stack.objects.get_or_create(
+        stack, _ = Stack.objects.get_or_create(
             student_id=student_id,
             course_id=course_id,
             name=self.block.stack_name,
@@ -143,7 +145,7 @@ class TestHastexoXBlock(TestCase):
         timedelta = timezone.timedelta(seconds=(suspend_timeout - 1))
         suspend_timestamp = timezone.now() - timedelta
         course_id, student_id = self.block.get_block_ids()
-        stack, _ = hastexo.models.Stack.objects.get_or_create(
+        stack, _ = Stack.objects.get_or_create(
             student_id=student_id,
             course_id=course_id,
             name=self.block.stack_name,
@@ -179,7 +181,7 @@ class TestHastexoXBlock(TestCase):
         timedelta = timezone.timedelta(seconds=(suspend_timeout - 1))
         suspend_timestamp = timezone.now() - timedelta
         course_id, student_id = self.block.get_block_ids()
-        stack, _ = hastexo.models.Stack.objects.get_or_create(
+        stack, _ = Stack.objects.get_or_create(
             student_id=student_id,
             course_id=course_id,
             name=self.block.stack_name,
@@ -239,7 +241,7 @@ class TestHastexoXBlock(TestCase):
         with patch.multiple(self.block,
                             check_progress_task=DEFAULT,
                             check_progress_task_result=DEFAULT) as mocks:
-            with patch.dict(hastexo.utils.DEFAULT_SETTINGS,
+            with patch.dict(DEFAULT_SETTINGS,
                             {'check_timeout': check_timeout}):
                 mocks['check_progress_task'].return_value = mock_result
                 mocks['check_progress_task_result'].return_value = mock_result

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,12 @@
 #
 # Until that is fixed, run tests on Python 3.5 but ignore errors.
 [tox]
-envlist = py{27,35}-xblock{100,111},flake8
+envlist = py{27,35}-xblock{10,11,12},flake8
 
 [travis]
 python =
-  2.7: py27-xblock{100,111},flake8
-  3.5: py35-xblock{100,111},flake8
+  2.7: py27-xblock{10,11,12},flake8
+  3.5: py35-xblock{10,11,12},flake8
 
 [flake8]
 ignore = E124
@@ -16,8 +16,9 @@ exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,build,dist,src
 [testenv]
 deps =
     -rrequirements/test.txt
-    xblock100: XBlock==1.0.0
-    xblock111: XBlock==1.1.1
+    xblock10: XBlock==1.0.0
+    xblock11: XBlock==1.1.1
+    xblock12: XBlock==1.2.1
 commands =
     py27: python run_tests.py []
     py35: - python run_tests.py []


### PR DESCRIPTION
This is an extension of PR #72, adding the 1.2.1 version of the XBlock library to the test matrix. 