### PR TITLE
Security: bump paramiko version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ keystoneauth1==3.11.0
 python-keystoneclient==3.17.0
 python-heatclient==1.6.1
 python-novaclient==7.1.2
-paramiko==2.1.5
+paramiko==2.1.6
 celery==3.1.18
 apscheduler==3.5.1
 -e git+https://github.com/edx/xblock-utils.git@v1.0.5#egg=xblock-utils==v1.0.5

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'python-keystoneclient==3.17.0',
         'python-heatclient==1.6.1',
         'python-novaclient==7.1.2',
-        'paramiko==2.1.5',
+        'paramiko==2.1.6',
         'apscheduler==3.5.1',
     ],
     entry_points={


### PR DESCRIPTION
The server-side vulnerability in Paramiko 2.1.5 does not affect us
(we're only using Paramiko in client mode), but it doesn't hurt
to require a version where the vulnerability is fixed.

References:
https://nvd.nist.gov/vuln/detail/CVE-2018-1000805
https://github.com/paramiko/paramiko/issues/1283