### PR TITLE
Bump XBlock 1.2 testing to version 1.2.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     -rrequirements/test.txt
     xblock10: XBlock==1.0.0
     xblock11: XBlock==1.1.1
-    xblock12: XBlock==1.2.1
+    xblock12: XBlock==1.2.2
 commands =
     py27: python run_tests.py []
     py35: - python run_tests.py []


### PR DESCRIPTION
XBlock 1.2.2 was released on 2018-09-07, update the test matrix
to that release for XBlock 1.2.