### PR TITLE
Improve warning messages

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+---------------------------
+
+* [Enhancement] Improve learner-facing warning messages
+
 Version 2.5.5 (2019-01-30)
 ---------------------------
 

--- a/hastexo/static/html/error.html
+++ b/hastexo/static/html/error.html
@@ -1,7 +1,7 @@
 <div class="hastexo_block">
   <div class="error">
     <div class="inner">
-      <h1>Whoops!</h1>
+      <h1>Sorry!</h1>
       <p class="message">There was a problem preparing your lab environment:</p>
       <p class="error_msg">{{ error_msg }}</p>
     </div>

--- a/hastexo/static/html/main.html
+++ b/hastexo/static/html/main.html
@@ -16,7 +16,7 @@
   </div>
   <div class="dialog" id="launch_error">
     <div class="inner">
-      <h1>Whoops!</h1>
+      <h1>Sorry!</h1>
       <p class="message"></p>
       <p class="error_msg"></p>
       <p class="buttons">
@@ -42,7 +42,7 @@
   </div>
   <div class="dialog" id="check_error">
     <div class="inner">
-      <h1>Whoops!</h1>
+      <h1>Sorry!</h1>
       <p class="message">There was a problem checking your progress:</p>
       <p class="error_msg"></p>
       <p class="buttons">

--- a/hastexo/static/html/main.html
+++ b/hastexo/static/html/main.html
@@ -64,7 +64,9 @@
   <div class="dialog" id="reset_dialog">
     <div class="inner">
       <h1>Are you sure?</h1>
-      <p class="message">Resetting your lab environment cannot be undone!</p>
+      <p class="message">Resetting will return your lab environment to a pristine state.<br/>
+	After you reset, you will need to retrace your steps up to this point.<br/>
+	You cannot undo this action.</p>
       <p class="buttons">
         <input type="button" class="reset" value="Reset"></input>
         <input type="button" class="cancel" value="Cancel"></input>


### PR DESCRIPTION
* Say "Sorry", not "Whoops",
* Make it clearer that reset means reset.