### PR TITLE
Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: python
 python:
   - "2.7"
   - "3.5"
+  - "3.6"
 
 before_install:
   - pip install codecov

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+Unreleased
+---------------------------
+
+* [Enhancement] Track XBlock-SDK master branch in test matrix
+* [Bug fix] Python 3.6 compatibility
+
 Version 2.5.6 (2018-02-07)
 ---------------------------
 

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -396,7 +396,7 @@ class HastexoXBlock(XBlock,
                 provider_name = "default"
             else:
                 try:
-                    provider_name = configured_providers.iterkeys().next()
+                    provider_name = next(iter(configured_providers))
                 except StopIteration:
                     pass
 

--- a/hastexo/tasks.py
+++ b/hastexo/tasks.py
@@ -12,6 +12,9 @@ from celery.exceptions import SoftTimeLimitExceeded
 from heatclient.exc import HTTPException, HTTPNotFound
 from keystoneauth1.exceptions.http import HttpError
 from io import StringIO
+from paramiko.ssh_exception import (AuthenticationException,
+                                    SSHException,
+                                    NoValidConnectionsError)
 
 from .models import Stack
 from .heat import HeatWrapper
@@ -533,9 +536,9 @@ class LaunchStackTask(Task):
             try:
                 ssh.connect(stack_ip, username=self.stack_user_name, pkey=pkey)
             except (EOFError,
-                    paramiko.ssh_exception.AuthenticationException,
-                    paramiko.ssh_exception.SSHException,
-                    paramiko.ssh_exception.NoValidConnectionsError):
+                    AuthenticationException,
+                    SSHException,
+                    NoValidConnectionsError):
                 self.sleep()
             except SoftTimeLimitExceeded:
                 raise

--- a/hastexo/tasks.py
+++ b/hastexo/tasks.py
@@ -59,7 +59,7 @@ class LaunchStackTask(Task):
         Run the celery task.
 
         """
-        for key, value in kwargs.iteritems():
+        for key, value in kwargs.items():
             setattr(self, key, value)
 
         self.settings = get_xblock_settings()
@@ -660,7 +660,7 @@ class CheckStudentProgressTask(Task):
         Run the celery task.
 
         """
-        for key, value in kwargs.iteritems():
+        for key, value in kwargs.items():
             setattr(self, key, value)
 
         try:

--- a/hastexo/utils.py
+++ b/hastexo/utils.py
@@ -98,7 +98,7 @@ def get_credentials(settings, provider):
     # Sanitize credentials
     if credentials and isinstance(credentials, dict):
         tmp = {}
-        for key, default in DEFAULT_CREDENTIALS.iteritems():
+        for key, default in DEFAULT_CREDENTIALS.items():
             tmp[key] = credentials.get(key, default)
         credentials = tmp
 
@@ -116,7 +116,7 @@ def update_stack(name, course_id, student_id, data):
 
 
 def update_stack_fields(stack, data):
-    for field, value in data.iteritems():
+    for field, value in data.items():
         if hasattr(stack, field):
             setattr(stack, field, value)
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,7 @@
 -r base.txt
--e git://github.com/edx/xblock-sdk.git@v0.1.2#egg=xblock-sdk==v0.1.2
+-e git://github.com/edx/xblock-sdk.git@master#egg=xblock-sdk==master
+lazy
+nose
 mock
 tox
 coverage

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -195,7 +195,7 @@ class TestHastexoTasks(TestCase):
                                    self.settings),
         }
         self.mocks = {}
-        for mock_name, patcher in patchers.iteritems():
+        for mock_name, patcher in patchers.items():
             self.mocks[mock_name] = patcher.start()
             self.addCleanup(patcher.stop)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
-# XBlock 1.0.0+ supports Python 3, but the XBlock SDK / Workbench does not (yet).
-#
-# Until that is fixed, run tests on Python 3.5 but ignore errors.
 [tox]
-envlist = py{27,35}-xblock{10,11,12},flake8
+envlist = py{27,35,36}-xblock{10,11,12},flake8
 
 [travis]
 python =
   2.7: py27-xblock{10,11,12},flake8
   3.5: py35-xblock{10,11,12},flake8
+  3.6: py36-xblock{10,11,12},flake8
 
 [flake8]
 ignore = E124,W504
@@ -21,10 +19,16 @@ deps =
     xblock12: XBlock==1.2.2
 commands =
     py27: python run_tests.py []
+    # In Python 3.5, we have an issue with JSON getting binary input
+    # where it expects a string. This issue was fixed in Python 3.6:
+    #
+    # https://docs.python.org/3/whatsnew/3.6.html#json
+    #
+    # Until we decide to either drop Python 3.5 support or make our
+    # use of JSON play nicely with 3.5, run the tests but ignore
+    # errors ("- " prefix).
     py35: - python run_tests.py []
-# When Workbench Python 3 support is fixed, replace with:
-# commands =
-#     python run_tests.py []
+    py36: python run_tests.py []
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
It looks as though by tracking the `master` branch of edx/xblock-sdk, we can finally get the test harness to run in Python 3, so I took a stab at eliminating what's left of Python 2-only code.

- Replace `dict.iteritems()` and `dict.iterkeys()`
- Import Paramiko SSH exceptions, rather than referencing them by fully qualified class name
- Add Python 3.6 to the test matrix and require it to pass (but not 3.5 — see the relevant commit message for an explanation)