### PR TITLE
Progress check hints via stderr

### DIFF
--- a/hastexo/public/css/main.css
+++ b/hastexo/public/css/main.css
@@ -110,9 +110,19 @@
 }
 
 .inner h1,
+.inner h2,
 .inner p {
     text-align: center !important;
     margin: 0 0 0.5em 0!important;
+}
+
+.hints_title {
+    color: red;
+    padding-top: 0.5em;
+}
+
+.hints {
+    font-size: 0.8em;
 }
 
 .dialog {

--- a/hastexo/public/js/main.js
+++ b/hastexo/public/js/main.js
@@ -444,6 +444,17 @@ function HastexoXBlock(runtime, element, configuration) {
                     dialog.find('input.ok').one('click', function() {
                         $.dialog.close();
                     });
+                    var hints_title = dialog.find('.hints_title').hide();
+                    var hints = dialog.find('.hints').empty().hide();
+                    if (data.errors.length > 0) {
+                        $.each(data.errors, function(i, error) {
+                            var pre = $('<pre>', {text: error});
+                            var li = $('<li>').append(pre);
+                            hints.append(li);
+                        });
+                        hints_title.show();
+                        hints.show();
+                    }
                     dialog.dialog(element);
                 } else if (check.status == 'CHECK_PROGRESS_PENDING') {
                     dialog = $('#check_pending');

--- a/hastexo/static/html/main.html
+++ b/hastexo/static/html/main.html
@@ -35,6 +35,8 @@
     <div class="inner">
       <h1>Progress check result</h1>
       <p class="message">You completed <strong class="check_pass">0</strong> out of <strong class="check_total">0</strong> tasks.</p>
+      <h2 class="hints_title">Hints</h2>
+      <ul class="hints"></ul>
       <p class="buttons">
         <input type="button" class="ok" value="Ok"></input>
       </p>


### PR DESCRIPTION
Allow course authors to specify progress check hints by outputting
arbitrary messages on a script's stderr when it fails.