### PR TITLE
Reaper zombie destroyer

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 3.0.1
+current_version = 3.1.0
 
 [bumpversion:file:guacamole/pom.xml]
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-Unreleased
+Version 3.1.0 (2019-07-26)
 ---------------------------
 
 * [BACKWARD INCOMPATIBLE FOR GCP LABS ONLY] Encode GCP stack names

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+Unreleased
+---------------------------
+
+* [BACKWARD INCOMPATIBLE FOR GCP LABS ONLY] Encode GCP stack names
+* [Enhancement] Provider stack listing
+* [Enhancement] Reaper zombie destroyer
+* [Enhancement] Add Python 3.7 test target
+
 Version 3.0.1 (2019-07-23)
 ---------------------------
 

--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.hastexo.xblock</groupId>
     <artifactId>hastexo-xblock</artifactId>
     <packaging>war</packaging>
-    <version>3.0.1</version>
+    <version>3.1.0</version>
     <name>hastexo-xblock</name>
     <url>http://github.com/hastexo/hastexo-xblock/</url>
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py{27,35,36}-xblock{10,11,12},flake8
+envlist = py{27,35,36,37}-xblock{10,11,12},flake8
 
 [travis]
 python =
   2.7: py27-xblock{10,11,12},flake8
   3.5: py35-xblock{10,11,12},flake8
   3.6: py36-xblock{10,11,12},flake8
+  3.7: py37-xblock{10,11,12},flake8
 
 [flake8]
 ignore = E124,W504
@@ -30,6 +31,7 @@ commands =
     # errors ("- " prefix).
     py35: - python run_tests.py []
     py36: python run_tests.py []
+    py37: python run_tests.py []
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
It so happens that the Heat API, when under yet-undetermined but clearly adverse conditions (usually after long-running, failed launch attempts), will report a 404 for a stack that is actually still there.  This causes the XBlock state machine to remember that stack as deleted, with the undesireable effect that if the owning user never tries to launch that stack again, it will never be considered for reaping.

To avoid having such useless stacks lying around accruing running charges, this implements a catch-all phase to the reaper run.  This phase will list all stacks on each configured provider and compare each stack to its corresponding state in the database.  If the stack is deemed to be a zombie (i.e., it is known to be dead, but clearly isn't), it is immediately destroyed.
