### PR TITLE
Minor testing improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 sudo: false
 
+dist: xenial
+
 language: python
 
 python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 before_install:
   - pip install codecov

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     -rrequirements/test.txt
     xblock10: XBlock==1.0.0
     xblock11: XBlock==1.1.1
-    xblock12: XBlock==1.2.2
+    xblock12: XBlock==1.2.3
 commands =
     py27: python run_tests.py []
     # In Python 3.5, we have an issue with JSON getting binary input


### PR DESCRIPTION
* Track latest upstream XBlock release, [1.2.3](https://pypi.org/project/XBlock/1.2.3/)
* Add Python 3.7 to the Travis test matrix (Python 3.7 was added to `tox.ini` in PR #96, but omitted from `.travis.yml`)