### PR TITLE
Support fully qualified terminal URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,12 @@ cloud you will be using.  All other variables can be left at their defaults.
 
 This is a brief explanation of each:
 
-* `terminal_url`: The URL path to the Guacamole web app.  It can be an absolute
-  path, or start with a ":"-prefixed port (such as ":8080/hastexo-xblock/", for
-  use in devstacks). (Default: `/hastexo-xblock/`)
+* `terminal_url`: URL to the Guacamole web app.  If it is defined with a fully
+  qualified domain, it must include the protocol (`http://` or `https://`).  If
+  not, it is assumed to be an absolute path based on the current
+  `window.location`.  (It is possible to define it with a ":"-prefixed port,
+  such as ":8080/hastexo-xblock/", for use in devstacks). (Default:
+  `/hastexo-xblock/`)
 
 * `launch_timeout`: How long to wait for a stack to be launched, in seconds.
   (Default: `900`)

--- a/hastexo/public/js/main.js
+++ b/hastexo/public/js/main.js
@@ -92,15 +92,22 @@ function HastexoXBlock(runtime, element, configuration) {
         }
 
         /* Process terminal URL. */
-        var prot_map = {
-            "http:":  "ws:",
-            "https:": "wss:"
-        };
-        var terminal_http_url = location.protocol + '//' + location.hostname + configuration.terminal_url;
-        var terminal_ws_url = prot_map[location.protocol] + '//' + location.hostname + configuration.terminal_url;
+        var terminal_http_url;
+        var terminal_ws_url;
+        if (configuration.terminal_url.startsWith('http')) {
+          terminal_http_url = configuration.terminal_url;
+          terminal_ws_url = configuration.terminal_url.replace('http', 'ws');
+        } else {
+          var prot_map = {
+              "http:":  "ws:",
+              "https:": "wss:"
+          };
+          terminal_http_url = location.protocol + '//' + location.hostname + configuration.terminal_url;
+          terminal_ws_url = prot_map[location.protocol] + '//' + location.hostname + configuration.terminal_url;
+        }
 
         /* Load app dynamically. */
-        $.cachedScript(terminal_http_url + '/guacamole-common-js/all.min.js').done(function() {
+        $.cachedScript(terminal_http_url + 'guacamole-common-js/all.min.js').done(function() {
             terminal_client = new Guacamole.Client(
                 new Guacamole.WebSocketTunnel(terminal_ws_url + "websocket-tunnel")
             );


### PR DESCRIPTION
Handle fully qualified terminal URLs correctly, instead of appending
them to the current domain.  This allows loading the Guacamole app from
an entirely different domain, if so desired.