### PR TITLE
Allow nested blocks

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 3.5.1
+current_version = 3.6.0
 
 [bumpversion:file:guacamole/pom.xml]
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-Unreleased
+Version 3.6.0 (2020-03-30)
 ---------------------------
 
 * [Enhancement] Allow nested blocks

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+---------------------------
+
+* [Enhancement] Allow nested blocks
+
 Version 3.5.1 (2020-03-25)
 ---------------------------
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,20 @@ To deploy the hastexo XBlock:
     ],
     ```
 
-4. This xblock uses a Django model to synchronize stack information across
+4. If you're going to use it in a content library, also add it to the
+   `ADVANCED_PROBLEM_TYPES` of your Studio environment, by editing
+   `/edx/app/edxapp/cms.env.json` and adding:
+
+    ```
+    "ADVANCED_PROBLEM_TYPES": [
+        {
+            "boilerplate_name": null,
+            "component": "hastexo"
+        }
+    ],
+    ```
+
+5. This xblock uses a Django model to synchronize stack information across
    instances.  Migrate the `edxapp` database so the `hastexo_stack` table is
    created:
 
@@ -85,7 +98,7 @@ To deploy the hastexo XBlock:
    $ sudo /edx/bin/edxapp-migrate-lms
    ```
 
-5. Add configuration to `XBLOCK_SETTINGS` on `/edx/app/edxapp/lms.env.json`:
+6. Add configuration to `XBLOCK_SETTINGS` on `/edx/app/edxapp/lms.env.json`:
 
     ```
     "XBLOCK_SETTINGS": {
@@ -144,7 +157,7 @@ To deploy the hastexo XBlock:
     }
     ```
 
-6. Now install the Guacamole web app and stack supervisor scripts by cloning
+7. Now install the Guacamole web app and stack supervisor scripts by cloning
    the `hastexo_xblock` fork of edx/configuration and assigning that role to
    the machine:
 
@@ -154,7 +167,7 @@ To deploy the hastexo XBlock:
     $ ansible-playbook -c local -i "localhost," run_role.yml -e role=hastexo_xblock
     ```
 
-7. At this point restart edxapp, its workers, and make sure the stack jobs are
+8. At this point restart edxapp, its workers, and make sure the stack jobs are
    running:
 
     ```
@@ -164,7 +177,7 @@ To deploy the hastexo XBlock:
     sudo /edx/bin/supervisorctl start reaper:
     ```
 
-8. Finally, in your course, go to the advanced settings and add the hastexo
+9. Finally, in your course, go to the advanced settings and add the hastexo
    module to the "Advanced Module List" like so:
 
    ```
@@ -565,6 +578,36 @@ In order to add the hastexo Xblock through Studio, open the unit where you want
 it to go.  Add a new component, select `Advanced`, then select the `Lab`
 component.  This adds the XBlock.  Edit the Settings as explained above.
 
+### Using the hastexo XBlock in a content library
+
+This XBlock is usable in [content libraries](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_components/libraries.html).
+It supports adding lab instructions as child blocks, so that when the block is
+randomized, the instructions are bundled together with it.
+
+To add the XBlock to the library via Studio, make sure it is configured as one
+of the `ADVANCED_PROBLEM_TYPES` in `cms.env.json`, then select it as such when
+adding content to your library.  (Note: as of Open edX Ironwood, the ability to
+do so requires running a [patched version](https://github.com/hastexo/edx-platform/tree/hastexo/ironwood/free_the_library)
+of `edx-platform`.)
+
+The following child block types are currently supported:
+
+    * html
+    * video
+    * [pdf](https://github.com/MarCnu/pdfXBlock)
+
+If using OLX, html blocks can be defined separately in the `html` subdirectory
+as usual, with the child element referring to it by URL name:
+
+```
+<vertical url_name="lab_introduction">
+  <hastexo ...>
+    <html url_name="lab_instructions">
+  </hastexo>
+</vertical>
+```
+
+Child blocks will always be rendered _above_ the terminal.
 
 ## Student experience
 

--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.hastexo.xblock</groupId>
     <artifactId>hastexo-xblock</artifactId>
     <packaging>war</packaging>
-    <version>3.5.1</version>
+    <version>3.6.0</version>
     <name>hastexo-xblock</name>
     <url>http://github.com/hastexo/hastexo-xblock/</url>
 

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -272,17 +272,6 @@ class HastexoXBlock(XBlock,
         The primary view of the HastexoXBlock, shown to students when viewing
         courses.
         """
-        def error_frag(msg):
-            """ Build a fragment to display runtime errors. """
-            context = {'error_msg': msg}
-            html = loader.render_template('static/html/error.html', context)
-            frag = Fragment(html)
-            frag.add_css_url(
-                self.runtime.local_resource_url(self,
-                                                'public/css/main.css')
-            )
-            return frag
-
         # Load configuration
         settings = get_xblock_settings()
 

--- a/hastexo/public/js/main.js
+++ b/hastexo/public/js/main.js
@@ -11,8 +11,12 @@ function HastexoXBlock(runtime, element, configuration) {
     var terminal_client = undefined;
     var terminal_element = undefined;
     var terminal_connected = false;
+    var dialog_container = undefined;
 
     var init = function() {
+        /* Set dialog container. */
+        dialog_container = $(element).find('.hastexblock')[0];
+
         /* Bind reset button action. */
         $(element).find('.buttons.bar > .reset').on('click', reset_dialog);
 
@@ -50,7 +54,7 @@ function HastexoXBlock(runtime, element, configuration) {
                         $.dialog.close();
                         location.reload();
                     });
-                    dialog.dialog(element);
+                    dialog.dialog(dialog_container);
                 }
 
                 if (terminal_connected) {
@@ -259,7 +263,7 @@ function HastexoXBlock(runtime, element, configuration) {
                     $.dialog.close();
                     location.reload();
                 });
-                dialog.dialog(element);
+                dialog.dialog(dialog_container);
             };
 
             get_user_stack_status(true);
@@ -276,7 +280,7 @@ function HastexoXBlock(runtime, element, configuration) {
     };
 
     var get_user_stack_status = function(initialize = false, reset = false) {
-        $('#launch_pending').dialog(element);
+        $('#launch_pending').dialog(dialog_container);
         $.ajax({
             type: 'POST',
             url: runtime.handlerUrl(element, 'get_user_stack_status'),
@@ -352,7 +356,7 @@ function HastexoXBlock(runtime, element, configuration) {
                     $.dialog.close();
                     location.reload();
                 });
-                dialog.dialog(element);
+                dialog.dialog(dialog_container);
             }
 
             if (terminal_connected) {
@@ -398,7 +402,7 @@ function HastexoXBlock(runtime, element, configuration) {
                 $.dialog.close();
                 location.reload();
             });
-            dialog.dialog(element);
+            dialog.dialog(dialog_container);
         } else {
             /* Unexpected status.  Display error message. */
             if (keepalive_timer) clearTimeout(keepalive_timer);
@@ -413,7 +417,7 @@ function HastexoXBlock(runtime, element, configuration) {
                 $.dialog.close();
                 location.reload();
             });
-            dialog.dialog(element);
+            dialog.dialog(dialog_container);
         }
     };
 
@@ -435,7 +439,7 @@ function HastexoXBlock(runtime, element, configuration) {
     };
 
     var get_check_status = function() {
-        $('#check_pending').dialog(element);
+        $('#check_pending').dialog(dialog_container);
 
         var show_error = function(error_msg) {
             var dialog = $('#check_error');
@@ -447,7 +451,7 @@ function HastexoXBlock(runtime, element, configuration) {
                 $.dialog.close();
                 get_check_status();
             });
-            dialog.dialog(element);
+            dialog.dialog(dialog_container);
         };
 
         $.ajax({
@@ -481,10 +485,10 @@ function HastexoXBlock(runtime, element, configuration) {
                         hints_title.show();
                         hints.show();
                     }
-                    dialog.dialog(element);
+                    dialog.dialog(dialog_container);
                 } else if (check.status == 'CHECK_PROGRESS_PENDING') {
                     dialog = $('#check_pending');
-                    dialog.dialog(element);
+                    dialog.dialog(dialog_container);
                     if (check_timer) clearTimeout(check_timer);
                     check_timer = setTimeout(get_check_status, configuration.timeouts['check']);
                 } else {
@@ -513,7 +517,7 @@ function HastexoXBlock(runtime, element, configuration) {
             /* Start over. */
             get_user_stack_status(true);
         });
-        dialog.dialog(element);
+        dialog.dialog(dialog_container);
     };
 
     var reset_dialog = function() {
@@ -533,7 +537,7 @@ function HastexoXBlock(runtime, element, configuration) {
             get_user_stack_status(true, true);
         });
 
-        dialog.dialog(element);
+        dialog.dialog(dialog_container);
     };
 
     init();

--- a/hastexo/static/html/error.html
+++ b/hastexo/static/html/error.html
@@ -1,9 +1,0 @@
-<div class="hastexo_block">
-  <div class="error">
-    <div class="inner">
-      <h1>Sorry!</h1>
-      <p class="message">There was a problem preparing your lab environment:</p>
-      <p class="error_msg">{{ error_msg }}</p>
-    </div>
-  </div>
-</div>

--- a/hastexo/static/html/main.html
+++ b/hastexo/static/html/main.html
@@ -1,4 +1,5 @@
-<div class="hastexo_block">
+{{child_content|safe}}
+<div class="hastexblock"><!-- Don't use underscores in this div's class, as doing so breaks the dialog overlay. -->
   <div id="container">
     <div id="terminal"></div>
   </div>


### PR DESCRIPTION
Let the course author include HTML, PDF, or video blocks as children.

Motivation: to allow lab instructions be grouped together with the correct instance, when served as part of a content library.

TODO:
- [x] [Hack library to allow nested blocks](https://github.com/arbrandes/edx-platform/commit/ca0f8e0824d7125eb118cb0b837d876f3ed41eea)
- [x] Tests