### PR TITLE
Retry database status update

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+Unreleased
+----------
+* [Enhancement] Retry failed database updates from Celery tasks
+
 Version 3.4.2 (2020-01-23)
 ---------------------------
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,16 +1,22 @@
 -r base.txt
+
+# These package versions must be kept in sync with edx-platform as much as possible.
 django>=1.11.27,<1.12
 celery>=3.1.25,<4.0
+xblock-utils>=1.2.0,<1.3
+jsonfield==2.0.2
+six==1.11.0
+lazy==1.1
+django-pyfs==2.0
+mako==1.0.2
+sqlparse==0.2.4
+
+# XBlock SDK
 -e git://github.com/edx/xblock-sdk.git@master#egg=xblock-sdk==master
-xblock-utils
-jsonfield
-six
-lazy
+
+# Tooling
+ddt
 nose
 mock
 tox
 coverage
-django-pyfs
-mako
-ddt
-sqlparse

--- a/run_tests.py
+++ b/run_tests.py
@@ -27,8 +27,7 @@ if __name__ == "__main__":
     os.environ.setdefault("DJANGO_LIVE_TEST_SERVER_ADDRESS",
                           "localhost:8081-8099")
 
-    # Silence too verbose Django logging
-    logging.disable(logging.DEBUG)
+    logging.basicConfig()
 
     try:
         os.mkdir('var')


### PR DESCRIPTION
@arbrandes, maybe you still want to give this a look. It's a WIP PR for doing database update retries from tasks, and it would (currently) _only_ apply to the update at the very end of the stack launch.

The idea is, for that specific update, to retry on database errors until it either goes away, or we hit the stack timeout (obviously with a sleep in between).

 