### PR TITLE
Include SUSPEND_COMPLETE in OCCUPANCY_STATES

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 3.5.0
+current_version = 3.5.1
 
 [bumpversion:file:guacamole/pom.xml]
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-Unreleased
+Version 3.5.1 (2020-03-25)
 ---------------------------
 
 * [Bug fix] Include suspended stacks in count to assess provider

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
+Unreleased
+---------------------------
+
+* [Bug fix] Include suspended stacks in count to assess provider
+  capacity and utilization
+
 Version 3.5.0 (2020-03-19)
-----------
+---------------------------
 * [Enhancement] Retry failed database updates from Celery tasks
 
 Version 3.4.2 (2020-01-23)

--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.hastexo.xblock</groupId>
     <artifactId>hastexo-xblock</artifactId>
     <packaging>war</packaging>
-    <version>3.5.0</version>
+    <version>3.5.1</version>
     <name>hastexo-xblock</name>
     <url>http://github.com/hastexo/hastexo-xblock/</url>
 

--- a/hastexo/common.py
+++ b/hastexo/common.py
@@ -140,6 +140,7 @@ OCCUPANCY_STATES = (
     SUSPEND_PENDING,  # noqa: F821
     SUSPEND_ISSUED,  # noqa: F821
     SUSPEND_RETRY,  # noqa: F821
+    SUSPEND_COMPLETE,  # noqa: F821
     DELETE_PENDING  # noqa: F821
 )
 

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -543,9 +543,11 @@ class TestLaunchStackTask(HastexoTestCase):
         for i, p in enumerate(self.providers):
             p["capacity"] = capacity
             self.mock_providers[i].capacity = capacity
+            # A suspended stack counts toward the provider capacity,
+            # just like a freshly created one does.
             data = {
                 "provider": p["name"],
-                "status": "CREATE_COMPLETE"
+                "status": "SUSPEND_COMPLETE"
             }
             for j in range(0, capacity):
                 name = "stack_%d_%d" % (i, j)


### PR DESCRIPTION
When assessing whether a provider is at capacity or not, we would not include suspended stacks in the count. This meant that for stacks that use automatic suspend (where most stacks are suspended at any given time), the only trigger for using the non-default provider would have been for a stack launch to run into an error.

Instead, include `SUSPEND_COMPLETE` in `OCCUPANCY_STATES`, making them count toward provider utilization.

Also, modify the unit test simulating that a provider is full, so that it deals with suspended rather than freshly created stacks.