### PR TITLE
Always retry stack updates in asynchronous tasks

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 3.6.0
+current_version = 3.6.1
 
 [bumpversion:file:guacamole/pom.xml]
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+Unreleased
+---------------------------
+
+* [Bug fix] Always, rather than selectively, retry failed database
+  updates from Celery tasks
+
 Version 3.6.0 (2020-03-30)
 ---------------------------
 
@@ -11,6 +17,7 @@ Version 3.5.1 (2020-03-25)
 
 Version 3.5.0 (2020-03-19)
 ---------------------------
+
 * [Enhancement] Retry failed database updates from Celery tasks
 
 Version 3.4.2 (2020-01-23)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-Unreleased
+Version 3.6.1 (2020-04-15)
 ---------------------------
 
 * [Bug fix] Always, rather than selectively, retry failed database

--- a/guacamole/pom.xml
+++ b/guacamole/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.hastexo.xblock</groupId>
     <artifactId>hastexo-xblock</artifactId>
     <packaging>war</packaging>
-    <version>3.6.0</version>
+    <version>3.6.1</version>
     <name>hastexo-xblock</name>
     <url>http://github.com/hastexo/hastexo-xblock/</url>
 

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -775,12 +775,12 @@ class TestLaunchStackTask(HastexoTestCase):
         )
 
     @patch.object(LaunchStackTask,
-                  'update_stack',
+                  'update_stack_once',
                   side_effect=[OperationalError,
                                OperationalError,
                                None])
     def test_resume_suspended_stack_transient_operational_error(self,
-                                                             update_stack_patch):  # noqa: E501
+                                                                update_stack_once_patch):  # noqa: E501
         """
         Try to resume a previously suspended stack, but simulate a
         database error, only on the first three calls, to
@@ -805,9 +805,9 @@ class TestLaunchStackTask(HastexoTestCase):
         # Run
         LaunchStackTask().run(**self.kwargs)
 
-        # The update_stack() method would have to be called 3 times (2
+        # The update_stack_once() method would have to be called 3 times (2
         # failures with an OperationalError, then 1 success).
-        self.assertEqual(update_stack_patch.call_count, 3)
+        self.assertEqual(update_stack_once_patch.call_count, 3)
 
         # Fetch stack
         stack = self.get_stack()
@@ -817,12 +817,12 @@ class TestLaunchStackTask(HastexoTestCase):
         self.assertEqual(stack.provider, self.providers[1]["name"])
 
     @patch.object(LaunchStackTask,
-                  'update_stack',
+                  'update_stack_once',
                   side_effect=[OperationalError,
                                OperationalError,
                                OperationalError])
     def test_resume_suspended_stack_persistent_operational_error(self,
-                                                                 update_stack_patch):  # noqa: E501
+                                                                 update_stack_once_patch):  # noqa: E501
         """
         Try to resume a previously suspended stack, but simulate a
         persistent database error in the process. Such an error should cause
@@ -846,9 +846,9 @@ class TestLaunchStackTask(HastexoTestCase):
         with self.assertRaises(OperationalError):
             LaunchStackTask().run(**self.kwargs)
 
-        # The update_stack() method would have to be called 3 times
-        # (all failures with an OperationalError).
-        self.assertEqual(update_stack_patch.call_count, 3)
+        # The update_stack_once() method would have to be called 3
+        # times (all failures with an OperationalError).
+        self.assertEqual(update_stack_once_patch.call_count, 3)
 
         # Fetch stack
         stack = self.get_stack()


### PR DESCRIPTION
In Celery tasks, as of 0d09330fb8888632b18cf31ebd7ca39d4b664b42, we would specifically select when to do a one-shot update of a stack, and when to persistently retry. That doesn't make a lot of sense; instead, just be persistent every time.

* Rename `update_stack()` (the atomic one-shot update) to `update_stack_once()`.
* Rename `update_stack_retry()` (the persistent wrapper) to `update_stack()`.
* Always call `update_stack()`, whenever we need to save stack data.