### PR TITLE
Retry get_provider_stack_count()

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 Unreleased
 ---------------------------
 
+* [Bug fix] Retry database query to fetch per-provider stack count
 * [Documentation] Add documentation for maintainers (on how to cut a
   release)
 * [Documentation] Include README.md in the package’s PyPI description

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -865,10 +865,10 @@ class TestLaunchStackTask(HastexoTestCase):
                                                                 update_stack_once_patch):  # noqa: E501
         """
         Try to resume a previously suspended stack, but simulate a
-        database error, only on the first three calls, to
+        database error, only on the first two calls, to
         LaunchStackTask.update_stack(). Such an error should cause the
         stack update to be retried. When the error does not persist on
-        the fourth try, the task should succeed.
+        the third try, the task should succeed.
         """
 
         # Setup
@@ -908,7 +908,7 @@ class TestLaunchStackTask(HastexoTestCase):
         """
         Try to resume a previously suspended stack, but simulate a
         persistent database error in the process. Such an error should cause
-        the task to time out.
+        the task to fail.
         """
 
         # Setup


### PR DESCRIPTION
Rather than only retrying up to three times for updating the database
stack status, also apply that same logic to fetching the stack count
per provider.