### PR TITLE
Update test matrix, include XBlock 1.3

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+---------------------------
+
+* [Enhancement] Support XBlock 1.3 (Python 3 only)
+
 Version 3.6.2 (2020-05-05)
 ---------------------------
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,6 +10,7 @@ lazy==1.1
 django-pyfs==2.0
 mako==1.0.2
 sqlparse==0.2.4
+web-fragments<0.3.2
 
 # XBlock SDK
 -e git://github.com/edx/xblock-sdk.git@master#egg=xblock-sdk==master

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -538,7 +538,7 @@ class TestHastexoJobs(TestCase):
 
         # Assert
         stacklog = StackLog.objects.filter(stack_id=stack.id)
-        states = [l.status for l in stacklog]
+        states = [logentry.status for logentry in stacklog]
         expected_states = [
             state,
             SUSPEND_PENDING

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -262,7 +262,7 @@ class TestLaunchStackTask(HastexoTestCase):
                                OperationalError,
                                OperationalError])
     def test_create_stack_persistent_database_error(self,
-                                                   get_provider_stack_count_once_patch):  # noqa: E501
+                                                    get_provider_stack_count_once_patch):  # noqa: E501
         """
         Try to launch a new stack, but simulate a persistent database
         error in the process. Such an error should cause the task to

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37,38}-xblock{10,11,12},flake8
+envlist = py{27,35,36,37,38}-xblock{10,11,12},py{35,36,37,38}-xblock{13},flake8
 
 [travis]
 python =
@@ -20,6 +20,7 @@ deps =
     xblock10: XBlock>=1.0,<1.1
     xblock11: XBlock>=1.1,<1.2
     xblock12: XBlock>=1.2,<1.3
+    xblock13: XBlock>=1.3,<1.4
 commands =
     py27: python run_tests.py []
     # In Python 3.5, we have an issue with JSON getting binary input

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,11 @@ envlist = py{27,35,36,37,38}-xblock{10,11,12},py{35,36,37,38}-xblock{13},flake8
 
 [travis]
 python =
-  2.7: py27-xblock{10,11,12},flake8
-  3.5: py35-xblock{10,11,12},flake8
-  3.6: py36-xblock{10,11,12},flake8
-  3.7: py37-xblock{10,11,12},flake8
-  3.8: py38-xblock{10,11,12},flake8
+  2.7: py27,flake8
+  3.5: py35,flake8
+  3.6: py36,flake8
+  3.7: py37,flake8
+  3.8: py38,flake8
 
 [flake8]
 ignore = E124,W504

--- a/tox.ini
+++ b/tox.ini
@@ -17,9 +17,9 @@ exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg,src
 deps =
     -rrequirements/setup.txt
     -rrequirements/test.txt
-    xblock10: XBlock==1.0.0
-    xblock11: XBlock==1.1.1
-    xblock12: XBlock==1.2.9
+    xblock10: XBlock>=1.0,<1.1
+    xblock11: XBlock>=1.1,<1.2
+    xblock12: XBlock>=1.2,<1.3
 commands =
     py27: python run_tests.py []
     # In Python 3.5, we have an issue with JSON getting binary input


### PR DESCRIPTION
* Un-break the Python 2.7 tests that broke as a result of `web-fragments` dropping Python 2 compatibility in its 0.3.2 release.
* Add XBlock 1.3 to the test matrix (Python 3 only).
* Simplify test dependencies so that the tests always install the latest XBlock patch release within a minor.
* Simplify the Python version matrix for Travis.
* Fix a couple of flake8 errors that are only flagged in a Travis build.