### PR TITLE
Use retry decorator from tenacity for retry logic

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@ This is the last release to be tested against Python 2.7.
 Any subsequent releases will support Python 3 only.
 
 * [Enhancement] Support XBlock 1.3 (Python 3 only)
+* [Enhancement] Add a new dependency to a 3rd party library, tenacity
 
 Version 3.6.2 (2020-05-05)
 ---------------------------

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,4 +11,5 @@ paramiko>=2.1.6,<2.2
 python-heatclient>=1.6.1,<1.7
 python-keystoneclient>=3.17.0,<3.18
 python-novaclient>=7.1.2,<7.2
+tenacity>=6.2
 -e .

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         'python-heatclient',
         'python-keystoneclient',
         'python-novaclient',
+        'tenacity',
     ],
     entry_points={
         'xblock.v1': [


### PR DESCRIPTION
Replace retry logic for 'get_provider_stack_count' and
'update_stack' in tasks.py with the retry decorator from tenacity

Use 'retry=retry_if_exception_type(OperationalError)'
to only retry when OperationalError is caught.
Use 'stop=stop_after_attempt(3)' to limit the max attempts to 3
Use 'wait=wait_exponential()' to wait before each retry.
Use 'before_sleep' to close connection
Use 'after_log' to log retry attempts.
Use 'reraise=True' to reraise the last attempt’s exception

Reference:
https://tenacity.readthedocs.io/en/latest/