### PR TITLE
Force setuptools<45 for Python 2.7

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 Unreleased
 ---------------------------
 
+This is the last release to be tested against Python 2.7.
+Any subsequent releases will support Python 3 only.
+
 * [Enhancement] Support XBlock 1.3 (Python 3 only)
 
 Version 3.6.2 (2020-05-05)

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg,src
 
 [testenv]
 deps =
+    py27: setuptools<45
     -rrequirements/setup.txt
     -rrequirements/test.txt
     xblock10: XBlock>=1.0,<1.1


### PR DESCRIPTION
Recent versions of setuptools have dropped support for Python 2.7.
That doesn't break things in an actual Open edX Ironwood install,
which pins an earlier setuptools version anyway. Running setup.py from
tox, however, pulls in setuptools via setuptools-scm, and thus the
Python 2.7 build would break.

Force setuptools<45 from tox.ini, in the py27 environments.