### PR TITLE
Fix the b'' prefix for lab progress check hints

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+---------------------------
+
+* [Bug fix] Always display lab progress check hints as human readable strings
+
 Version 3.6.3 (2020-05-20)
 ---------------------------
 

--- a/hastexo/tasks.py
+++ b/hastexo/tasks.py
@@ -827,9 +827,10 @@ class CheckStudentProgressTask(HastexoTask):
             try:
                 remote_exec(ssh, test, reuse_sftp=sftp)
             except RemoteExecException as e:
-                error_msg = str(e)
-                if error_msg:
-                    errors.append(error_msg)
+                msg = e.args[0]
+                hint = msg.decode() if isinstance(msg, bytes) else str(msg)
+                if hint:
+                    errors.append(hint)
             else:
                 score += 1
 


### PR DESCRIPTION
We are seeing hints in progress checks for labs displayed with a
b'' prefix, suggesting that we are displaying a hint of
<class 'bytes'> instead of 'str'.

Add decoding of bytes for those instances.