### PR TITLE
Improve testing

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@ Unreleased
 
 * [Bug fix] Always display lab progress check hints as human readable strings
 * [Testing] Fix Python 3.5 tests
+* [Testing] Drop XBlock 1.1 from the test matrix
 
 Version 3.6.3 (2020-05-20)
 ---------------------------

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@ Unreleased
 ---------------------------
 
 * [Bug fix] Always display lab progress check hints as human readable strings
+* [Testing] Fix Python 3.5 tests
 
 Version 3.6.3 (2020-05-20)
 ---------------------------

--- a/tests/unit/test_hastexo.py
+++ b/tests/unit/test_hastexo.py
@@ -290,7 +290,15 @@ class TestHastexoXBlock(TestCase):
                                      make_request(data, method=method))
         if expect_json:
             self.assertEqual(response.status_code, 200)
-            return json.loads(response.body)
+            response_body = response.body
+            # json.loads() is smart enough to grok both bytes and str
+            # from Python 3.6 forward. However in Python 3.5 (Ubuntu
+            # Xenial), we must pass json.loads() a str, as it will
+            # choke on bytes.
+            if isinstance(response_body, bytes):
+                return json.loads(response.body.decode('utf-8'))
+            else:
+                return json.loads(response.body)
         return response
 
     def test_get_launch_timeout(self):

--- a/tox.ini
+++ b/tox.ini
@@ -24,15 +24,7 @@ deps =
     xblock13: XBlock>=1.3,<1.4
 commands =
     py27: python run_tests.py []
-    # In Python 3.5, we have an issue with JSON getting binary input
-    # where it expects a string. This issue was fixed in Python 3.6:
-    #
-    # https://docs.python.org/3/whatsnew/3.6.html#json
-    #
-    # Until we decide to either drop Python 3.5 support or make our
-    # use of JSON play nicely with 3.5, run the tests but ignore
-    # errors ("- " prefix).
-    py35: - python run_tests.py []
+    py35: python run_tests.py []
     py36: python run_tests.py []
     py37: python run_tests.py []
     py38: python run_tests.py []

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37,38}-xblock{10,11,12},py{35,36,37,38}-xblock{13},flake8
+envlist = py{27,35,36,37,38}-xblock{10,12},py{35,36,37,38}-xblock{13},flake8
 
 [travis]
 python =
@@ -19,7 +19,6 @@ deps =
     -rrequirements/setup.txt
     -rrequirements/test.txt
     xblock10: XBlock>=1.0,<1.1
-    xblock11: XBlock>=1.1,<1.2
     xblock12: XBlock>=1.2,<1.3
     xblock13: XBlock>=1.3,<1.4
 commands =


### PR DESCRIPTION
Small improvements to the test matrix:

* Fix Python 3.5 tests (important since that is the Python 3 version that Ubuntu Xenial ships with)
* Drop XBlock 1.1 from the test matrix (that XBlock minor release was never a dependency of any Open edX named release)