### PR TITLE
Fix management commands

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+Unreleased
+---------------------------
+
+* [Bug fix] Correctly include the "reaper" and "suspender" manage.py
+  commands in packaging.
+* [Testing] Include unit tests for the manage.py commands.
+
+
 Version 3.6.4 (2020-07-16)
 ---------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,10 @@ setup(
         ]
     },
     scripts=package_scripts(["bin"]),
-    package_data=package_data("hastexo", ["static", "public", "migrations"]),
+    package_data=package_data("hastexo",
+                              ["static",
+                               "public",
+                               "management",
+                               "migrations"]),
     setup_requires=['setuptools-scm'],
 )

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -1,0 +1,31 @@
+from django.core.management import call_command
+from django.test import TestCase
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+
+class SuspenderTestCase(TestCase):
+
+    @patch('hastexo.jobs.SuspenderJob')
+    def test_start_suspender(self, mock_suspender):
+        # We need to mock the scheduler here, because we obviously
+        # don't want to add an actual recurring job during testing
+        with patch('apscheduler.schedulers.blocking.BlockingScheduler'):
+            call_command('suspender')
+
+        # Did we create a new suspender job?
+        self.assertEqual(mock_suspender.call_count, 1)
+
+
+class ReaperTestCase(TestCase):
+
+    @patch('hastexo.jobs.ReaperJob')
+    def test_start_reaper(self, mock_reaper):
+        with patch('apscheduler.schedulers.blocking.BlockingScheduler'):
+            call_command('reaper')
+
+        # Did we create a new reaper job?
+        self.assertEqual(mock_reaper.call_count, 1)


### PR DESCRIPTION
* Ensure that the management commands are properly packaged, by adding the `management` subdirectory to `package_data`.
* Add minimal unit tests for the management commands.