### PR TITLE
Make terminal color scheme and font configurable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+---------------------------
+
+* [Enhancement] Make Guacamole terminal color scheme and font configurable
+
 Version 3.6.5 (2020-07-16)
 ---------------------------
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ To deploy the hastexo XBlock:
     "XBLOCK_SETTINGS": {
         "hastexo": {
             "terminal_url": "/hastexo-xblock/",
+            "terminal_color_scheme": "white-black",
+            "terminal_font_name": "monospace",
+            "terminal_font_size": 10,
             "launch_timeout": 900,
             "remote_exec_timeout": 300,
             "suspend_timeout": 120,
@@ -201,6 +204,18 @@ This is a brief explanation of each:
   `window.location`.  (It is possible to define it with a ":"-prefixed port,
   such as ":8080/hastexo-xblock/", for use in devstacks). (Default:
   `/hastexo-xblock/`)
+
+* `terminal_color_scheme`: Color scheme for the terminal window. Suitable values
+  are described in [Guacamole Documentation](https://guacamole.apache.org/doc/gug/configuring-guacamole.html#ssh).
+  For example, `foreground:rgb:ff/ff/ff;background:rgb:00/00/00` and
+  `white-black` both represent white text on a black background.
+  (Default: `white-black`)
+
+* `terminal_font_name`: The name of the font to use in terminal. A matching font
+  must be installed on the Guacamole server. (Default: `monospace`) 
+
+* `terminal_font_size`: The size of the font to use in terminal, in points.
+  (Default: `10`)
 
 * `launch_timeout`: How long to wait for a stack to be launched, in seconds.
   (Default: `900`)

--- a/guacamole/src/main/java/com/hastexo/xblock/HastexoWebSocketTunnelEndpoint.java
+++ b/guacamole/src/main/java/com/hastexo/xblock/HastexoWebSocketTunnelEndpoint.java
@@ -71,6 +71,9 @@ public class HastexoWebSocketTunnelEndpoint extends GuacamoleWebSocketTunnelEndp
         String key = request.getParameter("key");
         int width = request.getIntegerParameter("width");
         int height = request.getIntegerParameter("height");
+        String colorScheme = request.getParameter("color_scheme");
+        String fontName = request.getParameter("font_name");
+        int fontSize = request.getIntegerParameter("font_size");
 
         // Connection configuration
         GuacamoleConfiguration guacConfig = new GuacamoleConfiguration();
@@ -94,8 +97,9 @@ public class HastexoWebSocketTunnelEndpoint extends GuacamoleWebSocketTunnelEndp
             guacConfig.setParameter("encodings", "zrle ultra copyrect hextile zlib corre rre raw");
         } else {
             guacConfig.setParameter("private-key", key);
-            guacConfig.setParameter("color-scheme", "white-black");
-            guacConfig.setParameter("font-size", "10");
+            guacConfig.setParameter("color-scheme", colorScheme);
+            guacConfig.setParameter("font-name", fontName);
+            guacConfig.setParameter("font-size", fontSize);
         }
 
         // Set screen size

--- a/hastexo/common.py
+++ b/hastexo/common.py
@@ -148,6 +148,9 @@ SETTINGS_KEY = 'hastexo'
 
 DEFAULT_SETTINGS = {
     "terminal_url": "/hastexo-xblock/",
+    "terminal_color_scheme": "white-black",
+    "terminal_font_name": "monospace",
+    "terminal_font_size": 10,
     "launch_timeout": 900,
     "remote_exec_timeout": 300,
     "suspend_timeout": 120,

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -347,7 +347,10 @@ class HastexoXBlock(XBlock,
             "has_tests": len(self.tests) > 0,
             "protocol": self.stack_protocol,
             "ports": self.ports,
-            "port": stack.port
+            "port": stack.port,
+            "color_scheme": settings.get("terminal_color_scheme"),
+            "font_name": settings.get("terminal_font_name"),
+            "font_size": settings.get("terminal_font_size")
         })
 
         return frag

--- a/hastexo/public/js/main.js
+++ b/hastexo/public/js/main.js
@@ -327,7 +327,10 @@ function HastexoXBlock(runtime, element, configuration) {
                 'port': port,
                 'user': stack.user,
                 'key': stack.key,
-                'password': stack.password
+                'password': stack.password,
+                'color_scheme': configuration.color_scheme,
+                'font_name': configuration.font_name,
+                'font_size': configuration.font_size
             }));
             terminal_connected = true;
         } catch (e) {


### PR DESCRIPTION
Add configuration options to edit guacamole terminal color scheme
and font by defining the following variables via EDXAPP_XBLOCK_SETTINGS:
'terminal_color_scheme', 'terminal_font_name', 'terminal_font_size'.