### PR TITLE
Add configuration option for instructions layout

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+---------------------------
+
+* [Enhancement] Make instructions layout configurable
+
 Version 3.6.7 (2020-08-03)
 ---------------------------
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ To deploy the hastexo XBlock:
             "terminal_color_scheme": "white-black",
             "terminal_font_name": "monospace",
             "terminal_font_size": "10",
+            "instructions_layout": "above",
             "launch_timeout": 900,
             "remote_exec_timeout": 300,
             "suspend_timeout": 120,
@@ -216,6 +217,10 @@ This is a brief explanation of each:
 
 * `terminal_font_size`: The size of the font to use in terminal, in points.
   (Default: `10`)
+
+* `instructions_layout`: Configuration for instructions layout. It's possible
+  to set the position for instructions to be 'above', 'below', 'left' or 'right'
+  from the terminal window. (Default: `above`)
 
 * `launch_timeout`: How long to wait for a stack to be launched, in seconds.
   (Default: `900`)

--- a/hastexo/common.py
+++ b/hastexo/common.py
@@ -151,6 +151,7 @@ DEFAULT_SETTINGS = {
     "terminal_color_scheme": "white-black",
     "terminal_font_name": "monospace",
     "terminal_font_size": "10",
+    "instructions_layout": "above",
     "launch_timeout": 900,
     "remote_exec_timeout": 300,
     "suspend_timeout": 120,

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -350,7 +350,8 @@ class HastexoXBlock(XBlock,
             "port": stack.port,
             "color_scheme": settings.get("terminal_color_scheme"),
             "font_name": settings.get("terminal_font_name"),
-            "font_size": settings.get("terminal_font_size")
+            "font_size": settings.get("terminal_font_size"),
+            "instructions_layout": settings.get("instructions_layout")
         })
 
         return frag

--- a/hastexo/public/css/main.css
+++ b/hastexo/public/css/main.css
@@ -173,3 +173,17 @@
         box-shadow: 0 2.5em 0 0 #000;
     }
 }
+
+.content-side-by-side {
+    max-width: 1800px;
+    height: 42em;
+}
+
+.instructions-side-view {
+    height: 40em !important;
+    padding-left: 1%;
+}
+
+.terminal-side-view {
+    height: 40em !important;
+}

--- a/hastexo/public/js/main.js
+++ b/hastexo/public/js/main.js
@@ -14,6 +14,9 @@ function HastexoXBlock(runtime, element, configuration) {
     var dialog_container = undefined;
 
     var init = function() {
+        /* Construct the layout for instructions and terminal */
+        construct_layout();
+
         /* Set dialog container. */
         dialog_container = $(element).find('.hastexblock')[0];
 
@@ -268,6 +271,48 @@ function HastexoXBlock(runtime, element, configuration) {
 
             get_user_stack_status(true);
         });
+    };
+
+    var construct_layout = function() {
+        var instructions_layout = configuration.instructions_layout;
+
+        /* 'above' is the default layout and doesn't require any changes */
+        if (instructions_layout != 'above') {
+            /* find the vertical element containing the content */
+            var content = $('.vert-mod');
+
+            /* find the vertical elements that contain lab instructions and terminal */
+            var terminal_parent = $('#terminal').closest('.vert');
+            var instructions_parent = $('.lab_instructions').closest('.vert');
+
+            if (terminal_parent != 'undefined' && instructions_parent != 'undefined') {
+                if (instructions_layout === 'left' || instructions_layout === 'right') {
+                    $(content).addClass('content-side-by-side');
+                    $('.lab_instructions').addClass('instructions-side-view');
+                    $('#container').addClass('terminal-side-view');
+
+                    $(instructions_parent).css({
+                        'float': [instructions_layout],
+                        'width' : '40%',
+                        'height': '100%'
+                    });
+                    $(terminal_parent).css({
+                        ['margin-' + instructions_layout] : '40%',
+                        'height': '100%'
+                    });
+
+                    /* if terminal is on the left side, move terminal buttons to the left as well */
+                    if (instructions_layout === 'right') {
+                        $(element).find('.buttons').css({'text-align': 'left'});
+                    };
+                };
+                if (instructions_layout === 'below') {
+                    $(instructions_parent).insertAfter($(terminal_parent));
+                };
+            } else {
+                console.warn('Unable to modify content layout, elements not found');
+            };
+        };
     };
 
     /* Returns a fuzzy timeout that varies between plus or minus 25% of the


### PR DESCRIPTION
Add variable 'instructions_layout' to XBLOCK_SETTINGS that allows
positioning lab intructions either above, below, left or right
from the terminal window.