### PR TITLE
Minor fixes to accomodate instructions layout options

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+---------------------------
+
+* [Bug fix] Minor style fixes for layout options
+
 Version 3.6.8 (2020-08-11)
 ---------------------------
 

--- a/hastexo/public/css/main.css
+++ b/hastexo/public/css/main.css
@@ -67,6 +67,7 @@
     border-radius: 10px;
     text-align: center;
     z-index: 1001;
+    margin: 0 20px 0 10px;
 }
 
 .dialog-overlay:before {
@@ -176,7 +177,6 @@
 
 .content-side-by-side {
     max-width: 1800px;
-    height: 42em;
 }
 
 .instructions-side-view {

--- a/hastexo/public/js/main.js
+++ b/hastexo/public/js/main.js
@@ -287,9 +287,11 @@ function HastexoXBlock(runtime, element, configuration) {
 
             if (terminal_parent != 'undefined' && instructions_parent != 'undefined') {
                 if (instructions_layout === 'left' || instructions_layout === 'right') {
-                    $(content).addClass('content-side-by-side');
                     $('.lab_instructions').addClass('instructions-side-view');
                     $('#container').addClass('terminal-side-view');
+                    $(content).addClass('content-side-by-side');
+                    /* Make sure the xblock fits to content area */
+                    $(content).height($('.hastexblock').height() + 20);
 
                     $(instructions_parent).css({
                         'float': [instructions_layout],


### PR DESCRIPTION
Add margin to dialog-overlay to remove overlapping background and
shadow from the sides.
Calculate content height for side views dynamically to make sure
xblock fits the area.