### PR TITLE
Drop Python 2.7, add XBlock 1.4, add GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,58 @@
+image: python
+
+py35:
+  image: python:3.5
+  stage: build
+  script:
+    - pip install tox
+    - tox -e py35-xblock13,py35-xblock14,flake8
+  artifacts:
+    paths:
+      - .coverage*
+    expire_in: 5 minutes
+
+py36:
+  image: python:3.6
+  stage: build
+  script:
+    - pip install tox
+    - tox -e py36-xblock13,py36-xblock14,flake8
+  artifacts:
+    paths:
+      - .coverage*
+    expire_in: 5 minutes
+
+py37:
+  image: python:3.7
+  stage: build
+  script:
+    - pip install tox
+    - tox -e py37-xblock13,py37-xblock14,flake8
+  artifacts:
+    paths:
+      - .coverage*
+    expire_in: 5 minutes
+
+py38:
+  image: python:3.8
+  stage: build
+  script:
+    - pip install tox
+    - tox -e py38-xblock13,py38-xblock14,flake8
+  artifacts:
+    paths:
+      - .coverage*
+    expire_in: 5 minutes
+
+coverage:
+  stage: test
+  script:
+    - pip install coverage
+    - python -m coverage combine
+    - python -m coverage html
+    - python -m coverage report
+  coverage: '/TOTAL.*\s+(\d+\.\d+%)$/'
+  artifacts:
+    paths:
+      - htmlcov
+    expire_in: 1 week

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ dist: xenial
 language: python
 
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Unreleased
   test matrix. This in turn means that we have also removed XBlock 1.1
   and XBlock 1.2 from the test matrix (both of which rely on Python
   2).
+* [Testing] Include XBlock 1.4 in the test matrix.
 
 Version 3.6.10 (2020-10-21)
 ---------------------------

--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,9 @@ Unreleased
   and XBlock 1.2 from the test matrix (both of which rely on Python
   2).
 * [Testing] Include XBlock 1.4 in the test matrix.
+* [Testing] Include a .gitlab-ci.yml file for running CI tests
+  when mirroring this repository onto a public or private GitLab
+  instance.
 
 Version 3.6.10 (2020-10-21)
 ---------------------------

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,10 @@ Unreleased
   The global settings still only accepts 'delete_age' value in days but
   is now converted to seconds internally. In future releases the settings will
   begin to support suffixes 'd', 'h', 'm' and 's'.
+* [BACKWARD INCOMPATIBLE] This release removes Python 2.7 from the
+  test matrix. This in turn means that we have also removed XBlock 1.1
+  and XBlock 1.2 from the test matrix (both of which rely on Python
+  2).
 
 Version 3.6.10 (2020-10-21)
 ---------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38}-xblock{13},flake8
+envlist = py{35,36,37,38}-xblock{13,14},flake8
 
 [travis]
 python =
@@ -17,6 +17,7 @@ deps =
     -rrequirements/setup.txt
     -rrequirements/test.txt
     xblock13: XBlock>=1.3,<1.4
+    xblock14: XBlock>=1.4,<1.5
 commands =
     py35: python run_tests.py []
     py36: python run_tests.py []

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,15 @@ python =
 ignore = E124,W504
 exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg,src
 
+[coverage:run]
+parallel = True
+include =
+  hastexo/*.py
+  tests/*.py
+
+[coverage:report]
+precision = 2
+
 [testenv]
 deps =
     -rrequirements/setup.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py27-xblock{10,12},py{35,36,37,38}-xblock{13},flake8
+envlist = py{35,36,37,38}-xblock{13},flake8
 
 [travis]
 python =
-  2.7: py27,flake8
   3.5: py35,flake8
   3.6: py36,flake8
   3.7: py37,flake8
@@ -15,14 +14,10 @@ exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg,src
 
 [testenv]
 deps =
-    py27: setuptools<45
     -rrequirements/setup.txt
     -rrequirements/test.txt
-    xblock10: XBlock>=1.0,<1.1
-    xblock12: XBlock>=1.2,<1.3
     xblock13: XBlock>=1.3,<1.4
 commands =
-    py27: python run_tests.py []
     py35: python run_tests.py []
     py36: python run_tests.py []
     py37: python run_tests.py []


### PR DESCRIPTION
* Remove Python 2.7 (and any XBlock versions that support only Python 2) from the test matrix.
* Add XBlock 1.4 to the test matrix.
* Add a `.gitlab-ci.yml` file, in order to be able to use GitLab CI when this repo is being mirrored to a private or public GitLab instance.
