### PR TITLE
Fix support for nested video elements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+---------------------------
+
+* [Bug fix] Fix support for nested `<video>` elements
+
 Version 4.0.0 (2020-11-10)
 ---------------------------
 

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -255,13 +255,13 @@ class HastexoXBlock(XBlock,
         """
         additional_blocks = []
         try:
-            from xmodule.video_module.video_module import VideoDescriptor
+            from xmodule.video_module.video_module import VideoBlock
             _spec = NestedXBlockSpec(
-                VideoDescriptor, category="video", label=u"Video"
+                VideoBlock, category="video", label=u"Video"
             )
             additional_blocks.append(_spec)
         except ImportError:
-            logger.warning("Unable to import VideoDescriptor", exc_info=True)
+            logger.warning("Unable to import VideoBlock", exc_info=True)
 
         try:
             from pdf import pdfXBlock


### PR DESCRIPTION
edx-platform PR 20384 removed the VideoDescriptor class, and replaced it with VideoBlock.

PR reference: https://github.com/edx/edx-platform/pull/20384/