### PR TITLE
Refactor Course Export & Import

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 Unreleased
 ---------------------------
 
+* [Enhancement] Refactor course export/import logic. XBlock editable fields
+  are added as attributes to the <hastexo> element in a vertical block.
+  `hook_events`, `ports`, `providers` and `tests` are exported to a separate
+  xml file.
 * [Bug fix] Fix support for nested `<video>` elements
 
 Version 4.0.0 (2020-11-10)


### PR DESCRIPTION
Add XBlock editable fields as attributes to the <hastexo> element
in a vertical block during course export.

Write 'hook_events', 'ports', 'providers' and 'tests' to a separate
xml file.

Refactor course import to include XBlock data from a separate xml
file, node attributes and child nodes.