### PR TITLE
Add an option to display a terminal in read-only mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+
+* [Enhancement] Add an option to display a terminal in  `read-only` mode.
+
 Version 4.1.2 (2020-12-03)
 ----------
 

--- a/README.md
+++ b/README.md
@@ -514,6 +514,10 @@ The following are optional:
   releases. Using this attribute will allow setting the `delete_age` value per
   instance and configure it to have a shorter value.
 
+* `read_only`: Display a lab terminal in a `read-only` mode. If set to `True`,
+  a lab stack will be created or resumed as usual, the student can see the lab
+  terminal but is not able to interact with it. Default is `False`.
+
 You can also use the following nested XML options:
 
 * `providers`: A list of references to providers configured in the platform.

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -4,7 +4,7 @@ import os
 import textwrap
 
 from xblock.core import XBlock, XML_NAMESPACES
-from xblock.fields import Scope, Float, String, Dict, List, Integer
+from xblock.fields import Scope, Float, String, Dict, List, Integer, Boolean
 from xblock.fragment import Fragment
 from xblockutils.resources import ResourceLoader
 from xblockutils.studio_editable import (
@@ -99,6 +99,11 @@ class HastexoXBlock(XBlock,
         help="Delete stacks that haven't been resumed in this many seconds. "
              "Overrides the globally defined setting."
     )
+    read_only = Boolean(
+        default=False,
+        scope=Scope.settings,
+        help="Display the terminal window in read-only mode"
+    )
 
     # Set via XML
     hook_events = Dict(
@@ -167,7 +172,8 @@ class HastexoXBlock(XBlock,
         'delete_age',
         'ports',
         'providers',
-        'tests')
+        'tests',
+        'read_only')
 
     has_author_view = True
     has_score = True
@@ -357,6 +363,7 @@ class HastexoXBlock(XBlock,
         node.set('launch_timeout', str(self.launch_timeout or ''))
         node.set('hook_script', self.hook_script or '')
         node.set('delete_age', str(self.delete_age or ''))
+        node.set('read_only', str(self.read_only))
 
         # Include nested blocks in course export
         if self.has_children:
@@ -496,7 +503,8 @@ class HastexoXBlock(XBlock,
             "color_scheme": settings.get("terminal_color_scheme"),
             "font_name": settings.get("terminal_font_name"),
             "font_size": settings.get("terminal_font_size"),
-            "instructions_layout": settings.get("instructions_layout")
+            "instructions_layout": settings.get("instructions_layout"),
+            "read_only": self.read_only
         })
 
         return frag

--- a/hastexo/public/js/main.js
+++ b/hastexo/public/js/main.js
@@ -128,108 +128,110 @@ function HastexoXBlock(runtime, element, configuration) {
                 terminal_client.disconnect();
             };
 
-            /* Mouse handling */
-            var mouse = new Guacamole.Mouse(terminal_element);
+            if(!configuration.read_only) {
+                /* Mouse handling */
+                var mouse = new Guacamole.Mouse(terminal_element);
 
-            mouse.onmousedown =
-            mouse.onmouseup   =
-            mouse.onmousemove = function(mouseState) {
-                terminal_client.sendMouseState(mouseState);
+                mouse.onmousedown =
+                mouse.onmouseup   =
+                mouse.onmousemove = function(mouseState) {
+                    terminal_client.sendMouseState(mouseState);
 
-                /* Reset the idle timeout on mouse action. */
-                if (configuration.timeouts['idle']) {
-                    if (idle_timer) clearTimeout(idle_timer);
-                    idle_timer = setTimeout(idle, configuration.timeouts['idle']);
-                }
-            };
-
-            /* Keyboard handling.  */
-            var keyboard = new Guacamole.Keyboard(terminal_element);
-            var ctrl, shift = false;
-
-            keyboard.onkeydown = function (keysym) {
-                var cancel_event = true;
-
-                /* Don't cancel event on paste shortcuts. */
-                if (keysym == 0xFFE1 /* shift */
-                    || keysym == 0xFFE3 /* ctrl */
-                    || keysym == 0xFF63 /* insert */
-                    || keysym == 0x0056 /* V */
-                    || keysym == 0x0076 /* v */
-                ) {
-                    cancel_event = false;
-                }
-
-                /* Remember when ctrl or shift are down. */
-                if (keysym == 0xFFE1) {
-                    shift = true;
-                } else if (keysym == 0xFFE3) {
-                    ctrl = true;
-                }
-
-                /* Delay sending final stroke until clipboard is updated. */
-                if ((ctrl && shift && keysym == 0x0056) /* ctrl-shift-V */
-                    || (ctrl && keysym == 0x0076) /* ctrl-v */
-                    || (shift && keysym == 0xFF63) /* shift-insert */
-                ) {
-                    window.setTimeout(function() {
-                        terminal_client.sendKeyEvent(1, keysym);
-                    }, 50);
-                } else {
-                    terminal_client.sendKeyEvent(1, keysym);
-                }
-
-                return !cancel_event;
-            };
-
-            keyboard.onkeyup = function (keysym) {
-                /* Remember when ctrl or shift are released. */
-                if (keysym == 0xFFE1) {
-                    shift = false;
-                } else if (keysym == 0xFFE3) {
-                    ctrl = false;
-                }
-
-                /* Delay sending final stroke until clipboard is updated. */
-                if ((ctrl && shift && keysym == 0x0056) /* ctrl-shift-v */
-                    || (ctrl && keysym == 0x0076) /* ctrl-v */
-                    || (shift && keysym == 0xFF63) /* shift-insert */
-                ) {
-                    window.setTimeout(function() {
-                        terminal_client.sendKeyEvent(0, keysym);
-                    }, 50);
-                } else {
-                    terminal_client.sendKeyEvent(0, keysym);
-                }
-            };
-
-            $(terminal_element)
-                /* Set tabindex so that element can be focused.  Otherwise, no
-                 * keyboard events will be registered for it. */
-                .attr('tabindex', 1)
-                /* Focus on the element based on mouse movement.  Simply
-                 * letting the user click on it doesn't work. */
-                .hover(
-                    function() {
-                       var x = window.scrollX, y = window.scrollY;
-                       $(this).focus();
-                       window.scrollTo(x, y);
-                    }, function() {
-                       $(this).blur();
+                    /* Reset the idle timeout on mouse action. */
+                    if (configuration.timeouts['idle']) {
+                        if (idle_timer) clearTimeout(idle_timer);
+                        idle_timer = setTimeout(idle, configuration.timeouts['idle']);
                     }
-                )
-                /* Release all keys when the element loses focus. */
-                .blur(function() {
-                    keyboard.reset();
-                });
+                };
 
-            /* Handle paste events when the element is in focus. */
-            $(document).on('paste', function(e) {
-                var text = e.originalEvent.clipboardData.getData('text/plain');
-                if ($(terminal_element).is(":focus")) {
-                    terminal_client.setClipboard(text);
-                }
-            });
+                /* Keyboard handling.  */
+                var keyboard = new Guacamole.Keyboard(terminal_element);
+                var ctrl, shift = false;
+
+                keyboard.onkeydown = function (keysym) {
+                    var cancel_event = true;
+
+                    /* Don't cancel event on paste shortcuts. */
+                    if (keysym == 0xFFE1 /* shift */
+                        || keysym == 0xFFE3 /* ctrl */
+                        || keysym == 0xFF63 /* insert */
+                        || keysym == 0x0056 /* V */
+                        || keysym == 0x0076 /* v */
+                    ) {
+                        cancel_event = false;
+                    }
+
+                    /* Remember when ctrl or shift are down. */
+                    if (keysym == 0xFFE1) {
+                        shift = true;
+                    } else if (keysym == 0xFFE3) {
+                        ctrl = true;
+                    }
+
+                    /* Delay sending final stroke until clipboard is updated. */
+                    if ((ctrl && shift && keysym == 0x0056) /* ctrl-shift-V */
+                        || (ctrl && keysym == 0x0076) /* ctrl-v */
+                        || (shift && keysym == 0xFF63) /* shift-insert */
+                    ) {
+                        window.setTimeout(function() {
+                            terminal_client.sendKeyEvent(1, keysym);
+                        }, 50);
+                    } else {
+                        terminal_client.sendKeyEvent(1, keysym);
+                    }
+
+                    return !cancel_event;
+                };
+
+                keyboard.onkeyup = function (keysym) {
+                    /* Remember when ctrl or shift are released. */
+                    if (keysym == 0xFFE1) {
+                        shift = false;
+                    } else if (keysym == 0xFFE3) {
+                        ctrl = false;
+                    }
+
+                    /* Delay sending final stroke until clipboard is updated. */
+                    if ((ctrl && shift && keysym == 0x0056) /* ctrl-shift-v */
+                        || (ctrl && keysym == 0x0076) /* ctrl-v */
+                        || (shift && keysym == 0xFF63) /* shift-insert */
+                    ) {
+                        window.setTimeout(function() {
+                            terminal_client.sendKeyEvent(0, keysym);
+                        }, 50);
+                    } else {
+                        terminal_client.sendKeyEvent(0, keysym);
+                    }
+                };
+
+                $(terminal_element)
+                    /* Set tabindex so that element can be focused.  Otherwise, no
+                    * keyboard events will be registered for it. */
+                    .attr('tabindex', 1)
+                    /* Focus on the element based on mouse movement.  Simply
+                    * letting the user click on it doesn't work. */
+                    .hover(
+                        function() {
+                        var x = window.scrollX, y = window.scrollY;
+                        $(this).focus();
+                        window.scrollTo(x, y);
+                        }, function() {
+                        $(this).blur();
+                        }
+                    )
+                    /* Release all keys when the element loses focus. */
+                    .blur(function() {
+                        keyboard.reset();
+                    });
+
+                /* Handle paste events when the element is in focus. */
+                $(document).on('paste', function(e) {
+                    var text = e.originalEvent.clipboardData.getData('text/plain');
+                    if ($(terminal_element).is(":focus")) {
+                        terminal_client.setClipboard(text);
+                    }
+                });
+            }
 
             /* Error handling. */
             terminal_client.onerror = function(guac_error) {


### PR DESCRIPTION
This commit adds an optional XBlock attribute "read_only",
that allows to display a lab terminal in read-only mode.
If set to True, a stack will be created or resumed as usual,
the student can see the terminal but is unable to interact with it.
The value defaults to False.