### PR TITLE
Only add attributes to a provider when they have a value

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@ Unreleased
 --------------------------
 * [Enhancement] Run integration tests in GitHub Actions, rather than
   Travis CI.
+* [Bug fix] Only add `template` and `environment` attributes
+  to a provider during course export and import when they have a value.
+  Adding a `null` or `None` values can cause breakage with spinning up labs.
 * [Enhancement] Update test requirements.
 
 Version 4.1.3 (2020-12-11)

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -212,19 +212,23 @@ class HastexoXBlock(XBlock,
             name = node.attrib["name"]
             if not name:
                 raise KeyError("name")
-            capacity = node.attrib.get("capacity")
+            capacity = node.attrib.get("capacity", None)
             if capacity in (None, "None", ""):
+                # capacity should not be undefined
+                # set to -1 (unlimited) in case it is
                 capacity = -1
             else:
                 # This will raise a TypeError if the string literal
                 # cannot be converted
                 capacity = int(capacity)
-            template = node.attrib.get("template", None)
-            environment = node.attrib.get("environment", None)
             provider = {"name": name,
-                        "capacity": capacity,
-                        "template": template,
-                        "environment": environment}
+                        "capacity": capacity}
+            template = node.attrib.get("template", None)
+            if template not in (None, "None"):
+                provider["template"] = template
+            environment = node.attrib.get("environment", None)
+            if environment not in (None, "None"):
+                provider["environment"] = environment
             block.providers.append(provider)
 
     @classmethod
@@ -339,6 +343,17 @@ class HastexoXBlock(XBlock,
             if self.providers:
                 for provider in self.providers:
                     provider_node = etree.SubElement(root, 'provider')
+                    provider_template = provider.get("template", None)
+                    if provider_template in (None, "None"):
+                        provider.pop("template")
+                    provider_environment = provider.get("environment", None)
+                    if provider_environment in (None, "None"):
+                        provider.pop("environment")
+                    provider_capacity = provider.get("capacity", None)
+                    if provider_capacity in (None, "None", ""):
+                        # capacity should not be undefined
+                        # set to -1 (unlimited) in case it is
+                        provider["capacity"] = -1
                     self.add_dict_properties_to_node(provider, provider_node)
 
             if self.tests:

--- a/tests/unit/test_hastexo.py
+++ b/tests/unit/test_hastexo.py
@@ -42,8 +42,7 @@ class TestHastexoXBlockParsing(XmlTest, TestCase):
       stack_user_name='training'
       stack_protocol='rdp'
       launch_timeout='900'>
-      <provider name='provider1' capacity='20'
-        environment='hot_env1.yaml' />
+      <provider name='provider1' capacity='-1' />
       <provider name='provider2' capacity='30' template='hot_lab2.yaml'
         environment='hot_env2.yaml' />
       <provider name='provider3' capacity='0' template='hot_lab3.yaml'
@@ -68,7 +67,9 @@ class TestHastexoXBlockParsing(XmlTest, TestCase):
         self.assertEqual(block.launch_timeout, 900)
         self.assertEqual(len(block.providers), 3)
         self.assertEqual(block.providers[0]["name"], "provider1")
-        self.assertEqual(block.providers[0]["template"], None)
+        self.assertEqual(block.providers[0]["capacity"], -1)
+        self.assertNotIn("template", block.providers[0])
+        self.assertNotIn("environment", block.providers[0])
         self.assertEqual(block.providers[1]["template"], "hot_lab2.yaml")
         self.assertEqual(block.providers[1]["capacity"], 30)
         self.assertEqual(block.providers[2]["environment"], "hot_env3.yaml")
@@ -78,6 +79,25 @@ class TestHastexoXBlockParsing(XmlTest, TestCase):
         self.assertEqual(len(block.tests), 2)
         self.assertEqual(block.tests[0], "Multi-line\ntest 1\n")
         self.assertEqual(block.tests[1], "Multi-line\ntest 2\n")
+
+    def test_parsing_capacity_empty_values(self):
+        block = self.parse_xml_to_block(textwrap.dedent("""\
+    <?xml version='1.0' encoding='utf-8'?>
+    <hastexo
+      stack_template_path='hot_lab.yaml'
+      stack_user_name='training'>
+      <provider name='provider1'
+        environment='hot_env1.yaml' />
+      <provider name='provider2' capacity=''
+        environment='hot_env2.yaml' />
+      <provider name='provider3' capacity='None'
+        environment='hot_env3.yaml' />
+    </hastexo>
+        """).encode('utf-8'))
+
+        self.assertEqual(block.providers[0]["capacity"], -1)
+        self.assertEqual(block.providers[1]["capacity"], -1)
+        self.assertEqual(block.providers[2]["capacity"], -1)
 
     def test_parsing_deprecated_requires_name(self):
         with self.assertRaises(KeyError):

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -512,6 +512,16 @@ class TestLaunchStackTask(HastexoTestCase):
         self.assertEqual(stack.provider, self.providers[1]["name"])
         provider.suspend_stack.assert_called()
 
+    def test_undefined_capacity(self):
+        # Setup
+        self.providers[0].pop("capacity")
+        self.update_stack({"providers": self.providers})
+
+        # Assert LaunchStackTask() fails if capacity is not defined
+        # for a provider.
+        with self.assertRaises(KeyError):
+            LaunchStackTask().run(**self.kwargs)
+
     def test_infinite_capacity(self):
         # Setup
         provider = self.mock_providers[0]


### PR DESCRIPTION
Only add `template` and  `environment` attributes to a
provider during course export and import when they have a value.
Adding a `null` or `None` values can cause breakage with spinning up labs.