### PR TITLE
Run GitHub actions on pull_request, not only on push

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,6 +1,8 @@
 name: Python package
 
-on: [push]
+on:
+  - push
+  - pull_request
 
 jobs:
   build:


### PR DESCRIPTION
In order to make status checks work correctly for pull requests, we have to run the GitHub Actions on `pull_request`, in addition to `push`. Otherwise, the result of the workflow is never reported back to the original repository, and the status check hangs   indefinitely.

