### PR TITLE
Add attributes to make the XBlock more suitable for exams

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+Unreleased
+-------------------------
+[Enhancement] Make the progress check button label configurable.
+
 Version 4.1.5 (2021-01-25)
 --------------------------
 * [Bug fix] Fix ICMP connectivity check for IPv6-only stacks.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 Unreleased
 -------------------------
+[Enhancement] Allow to enable/disable displaying test stderr
+  output streams as hints.
 [Enhancement] Make the progress check button label configurable.
 
 Version 4.1.5 (2021-01-25)

--- a/README.md
+++ b/README.md
@@ -521,6 +521,9 @@ The following are optional:
 * `progress_check_label`: Set a label for the progress check button.
   For example: `Submit Answer` or `Check Progress` (Default).
 
+* `show_hints_on_error`: On progress check failure, display the tests' standard
+  error streams as hints. Default is `True`.
+
 You can also use the following nested XML options:
 
 * `providers`: A list of references to providers configured in the platform.

--- a/README.md
+++ b/README.md
@@ -518,6 +518,9 @@ The following are optional:
   a lab stack will be created or resumed as usual, the student can see the lab
   terminal but is not able to interact with it. Default is `False`.
 
+* `progress_check_label`: Set a label for the progress check button.
+  For example: `Submit Answer` or `Check Progress` (Default).
+
 You can also use the following nested XML options:
 
 * `providers`: A list of references to providers configured in the platform.

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -110,6 +110,12 @@ class HastexoXBlock(XBlock,
         help="Set the progress check button label. "
              "For example: \"Submit Answer\" or \"Check Progress\"(Default)."
     )
+    show_hints_on_error = Boolean(
+        default=True,
+        scope=Scope.settings,
+        help="On progress check failure, display the tests' standard error "
+             "streams as hints"
+    )
 
     # Set via XML
     hook_events = Dict(
@@ -169,6 +175,7 @@ class HastexoXBlock(XBlock,
     editable_fields = (
         'display_name',
         'progress_check_label',
+        'show_hints_on_error',
         'weight',
         'stack_template_path',
         'hook_script',
@@ -379,6 +386,7 @@ class HastexoXBlock(XBlock,
         node.set('xblock-family', self.entry_point)
         node.set('display_name', self.display_name)
         node.set('progress_check_label', self.progress_check_label)
+        node.set('show_hints_on_error', str(self.show_hints_on_error))
         node.set('weight', str(self.weight))
         node.set('stack_user_name', self.stack_user_name)
         node.set('stack_protocol', self.stack_protocol)
@@ -528,7 +536,8 @@ class HastexoXBlock(XBlock,
             "font_size": settings.get("terminal_font_size"),
             "instructions_layout": settings.get("instructions_layout"),
             "read_only": self.read_only,
-            "progress_check_label": self.progress_check_label
+            "progress_check_label": self.progress_check_label,
+            "show_hints_on_error": self.show_hints_on_error
         })
 
         return frag

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -104,6 +104,12 @@ class HastexoXBlock(XBlock,
         scope=Scope.settings,
         help="Display the terminal window in read-only mode"
     )
+    progress_check_label = String(
+        default='Check Progress',
+        scope=Scope.settings,
+        help="Set the progress check button label. "
+             "For example: \"Submit Answer\" or \"Check Progress\"(Default)."
+    )
 
     # Set via XML
     hook_events = Dict(
@@ -162,6 +168,7 @@ class HastexoXBlock(XBlock,
 
     editable_fields = (
         'display_name',
+        'progress_check_label',
         'weight',
         'stack_template_path',
         'hook_script',
@@ -371,6 +378,7 @@ class HastexoXBlock(XBlock,
         node.set("filename", filename)
         node.set('xblock-family', self.entry_point)
         node.set('display_name', self.display_name)
+        node.set('progress_check_label', self.progress_check_label)
         node.set('weight', str(self.weight))
         node.set('stack_user_name', self.stack_user_name)
         node.set('stack_protocol', self.stack_protocol)
@@ -519,7 +527,8 @@ class HastexoXBlock(XBlock,
             "font_name": settings.get("terminal_font_name"),
             "font_size": settings.get("terminal_font_size"),
             "instructions_layout": settings.get("instructions_layout"),
-            "read_only": self.read_only
+            "read_only": self.read_only,
+            "progress_check_label": self.progress_check_label
         })
 
         return frag

--- a/hastexo/public/js/main.js
+++ b/hastexo/public/js/main.js
@@ -26,6 +26,7 @@ function HastexoXBlock(runtime, element, configuration) {
         /* Display progress check button, if there are tests. */
         if (configuration.has_tests) {
             var button = $(element).find('.buttons .check');
+            button.attr("value", configuration.progress_check_label);
             button.show();
             button.on('click', get_check_status);
         }

--- a/hastexo/public/js/main.js
+++ b/hastexo/public/js/main.js
@@ -549,14 +549,16 @@ function HastexoXBlock(runtime, element, configuration) {
                     });
                     var hints_title = dialog.find('.hints_title').hide();
                     var hints = dialog.find('.hints').empty().hide();
-                    if (data.errors.length > 0) {
-                        $.each(data.errors, function(i, error) {
-                            var pre = $('<pre>', {text: error});
-                            var li = $('<li>').append(pre);
-                            hints.append(li);
-                        });
-                        hints_title.show();
-                        hints.show();
+                    if (configuration.show_hints_on_error) {
+                        if (data.errors.length > 0) {
+                            $.each(data.errors, function(i, error) {
+                                var pre = $('<pre>', {text: error});
+                                var li = $('<li>').append(pre);
+                                hints.append(li);
+                            });
+                            hints_title.show();
+                            hints.show();
+                        }
                     }
                     dialog.dialog(dialog_container);
                 } else if (check.status == 'CHECK_PROGRESS_PENDING') {


### PR DESCRIPTION
Make the progress check button label configurable via `progress_check_label` attribute.
Allow hiding/displaying progress check hints via `tests_show_stderr` attribute.