### PR TITLE
Add more configuration options for progress check result dialog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+-------------------------
+[Enhancement] Make the progress check result header configurable
+ and allow to enable/disable showing feedback for task completion.
+
 Version 4.1.6 (2021-01-26)
 -------------------------
 [Enhancement] Allow to enable/disable displaying test stderr

--- a/README.md
+++ b/README.md
@@ -521,8 +521,17 @@ The following are optional:
 * `progress_check_label`: Set a label for the progress check button.
   For example: `Submit Answer` or `Check Progress` (Default).
 
+* `show_feedback`: On progress check, show feedback on how many tasks out of total 
+  are completed. Default is `True`.
+
 * `show_hints_on_error`: On progress check failure, display the tests' standard
-  error streams as hints. Default is `True`.
+  error streams as hints.
+  When `show_feedback` is set to `False`, hints will never be displayed and having
+  this set to `True` will have no effect. Default is `True`.
+
+* `progress_check_result_heading`: Message to display on progress check result window.
+  This could be set to "Answer Submitted" for example, when choosing to not display
+  hints and feedback. Default is "Progress check result".
 
 You can also use the following nested XML options:
 

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -110,11 +110,27 @@ class HastexoXBlock(XBlock,
         help="Set the progress check button label. "
              "For example: \"Submit Answer\" or \"Check Progress\"(Default)."
     )
+    show_feedback = Boolean(
+        default=True,
+        scope=Scope.settings,
+        help="On progress check, show feedback on how many tasks out of total "
+             "are completed."
+    )
     show_hints_on_error = Boolean(
         default=True,
         scope=Scope.settings,
         help="On progress check failure, display the tests' standard error "
-             "streams as hints"
+             "streams as hints. When 'show_feedback' is set to False, hints "
+             "will never be displayed and setting this to True will have no "
+             "effect."
+    )
+    progress_check_result_heading = String(
+        default='Progress check result',
+        scope=Scope.settings,
+        help="Message to display on progress check result window. This could "
+             "be set to \"Answer Submitted\" for example, when choosing to "
+             "not display hints and feedback. Default is \"Progress check "
+             "result\"."
     )
 
     # Set via XML
@@ -175,6 +191,8 @@ class HastexoXBlock(XBlock,
     editable_fields = (
         'display_name',
         'progress_check_label',
+        'progress_check_result_heading',
+        'show_feedback',
         'show_hints_on_error',
         'weight',
         'stack_template_path',
@@ -387,6 +405,9 @@ class HastexoXBlock(XBlock,
         node.set('display_name', self.display_name)
         node.set('progress_check_label', self.progress_check_label)
         node.set('show_hints_on_error', str(self.show_hints_on_error))
+        node.set('show_feedback', str(self.show_feedback))
+        node.set('progress_check_result_heading',
+                 self.progress_check_result_heading)
         node.set('weight', str(self.weight))
         node.set('stack_user_name', self.stack_user_name)
         node.set('stack_protocol', self.stack_protocol)
@@ -537,7 +558,9 @@ class HastexoXBlock(XBlock,
             "instructions_layout": settings.get("instructions_layout"),
             "read_only": self.read_only,
             "progress_check_label": self.progress_check_label,
-            "show_hints_on_error": self.show_hints_on_error
+            "show_hints_on_error": self.show_hints_on_error,
+            "show_feedback": self.show_feedback,
+            "progress_check_result_heading": self.progress_check_result_heading
         })
 
         return frag

--- a/hastexo/public/js/main.js
+++ b/hastexo/public/js/main.js
@@ -542,6 +542,7 @@ function HastexoXBlock(runtime, element, configuration) {
                 var dialog;
                 if (check.status == 'CHECK_PROGRESS_COMPLETE') {
                     dialog = $('#check_complete');
+                    dialog.find('.check_result_heading').html(configuration.progress_check_result_heading);
                     dialog.find('.check_pass').html(data.pass);
                     dialog.find('.check_total').html(data.total);
                     dialog.find('input.ok').one('click', function() {
@@ -549,16 +550,20 @@ function HastexoXBlock(runtime, element, configuration) {
                     });
                     var hints_title = dialog.find('.hints_title').hide();
                     var hints = dialog.find('.hints').empty().hide();
-                    if (configuration.show_hints_on_error) {
-                        if (data.errors.length > 0) {
-                            $.each(data.errors, function(i, error) {
-                                var pre = $('<pre>', {text: error});
-                                var li = $('<li>').append(pre);
-                                hints.append(li);
-                            });
-                            hints_title.show();
-                            hints.show();
+                    if (configuration.show_feedback) {
+                        if (configuration.show_hints_on_error) {
+                            if (data.errors.length > 0) {
+                                $.each(data.errors, function(i, error) {
+                                    var pre = $('<pre>', {text: error});
+                                    var li = $('<li>').append(pre);
+                                    hints.append(li);
+                                });
+                                hints_title.show();
+                                hints.show();
+                            }
                         }
+                    } else {
+                        dialog.find('.check_result_message').hide()
                     }
                     dialog.dialog(dialog_container);
                 } else if (check.status == 'CHECK_PROGRESS_PENDING') {

--- a/hastexo/static/html/main.html
+++ b/hastexo/static/html/main.html
@@ -34,8 +34,8 @@
   </div>
   <div class="dialog" id="check_complete">
     <div class="inner">
-      <h1>Progress check result</h1>
-      <p class="message">You completed <strong class="check_pass">0</strong> out of <strong class="check_total">0</strong> tasks.</p>
+      <h1 class="check_result_heading">Progress check result</h1>
+      <p class="check_result_message">You completed <strong class="check_pass">0</strong> out of <strong class="check_total">0</strong> tasks.</p>
       <h2 class="hints_title">Hints</h2>
       <ul class="hints"></ul>
       <p class="buttons">


### PR DESCRIPTION
Add a new XBlock attribute `progress_check_result_heading` for
configuring the progress check result dialog message.
Add a new XBlock attribute `show_feedback` to enable/disable
showing feeback for tasks completion.