### PR TITLE
Fix exporting provider attributes 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+
+Unreleased
+-------------------------
+[Bug fix] Fix export error, when provider attributes are not defined.
+
 Version 4.1.7 (2021-01-29)
 -------------------------
 [Enhancement] Make the progress check result header configurable

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -375,12 +375,19 @@ class HastexoXBlock(XBlock,
             if self.providers:
                 for provider in self.providers:
                     provider_node = etree.SubElement(root, 'provider')
-                    provider_template = provider.get("template", None)
-                    if provider_template in (None, "None"):
-                        provider.pop("template")
-                    provider_environment = provider.get("environment", None)
-                    if provider_environment in (None, "None"):
-                        provider.pop("environment")
+                    # Not having a 'template' or an 'environment' defined for
+                    # a provider is a valid option.
+                    # Only try to remove these when defined but values are
+                    # None or "None" to avoid breaking the export.
+                    if 'template' in provider:
+                        provider_template = provider.get("template", None)
+                        if provider_template in (None, "None"):
+                            provider.pop("template")
+                    if 'environment' in provider:
+                        provider_environment = provider.get("environment",
+                                                            None)
+                        if provider_environment in (None, "None"):
+                            provider.pop("environment")
                     provider_capacity = provider.get("capacity", None)
                     if provider_capacity in (None, "None", ""):
                         # capacity should not be undefined


### PR DESCRIPTION
Provider attributes like `template` and `environment` will not be
added to the provider node during course export in case of None or
"None" values.
However, not defining those attributes at all will throw an error
during export.
Add an additional check to make sure export succeeds when these attributes
are not defined for a provider.