### PR TITLE
Change wording on progress check wait dialog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+Unreleased
+-------------------------
+* [Enhancement] Make progress check wait dialog wording more general
+  and more suitable for different progress check configurations.
 
 Version 4.1.8 (2021-02-02)
 -------------------------

--- a/hastexo/static/html/main.html
+++ b/hastexo/static/html/main.html
@@ -29,7 +29,7 @@
   <div class="dialog" id="check_pending">
     <div class="inner">
       <h1><span>Please wait</span><span class="loader"></span></h1>
-      <p class="message">We're checking your progress.</p>
+      <p class="message">Working</p>
     </div>
   </div>
   <div class="dialog" id="check_complete">


### PR DESCRIPTION
Make progress check wait dialog wording more general
and more suitable for different progress check configurations.
Instead of displaying "We're checking your progress", display "Working"