### PR TITLE
Allow overriding hastexo_guacamole_client settings

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+Unreleased
+-----------------------------
+* [Enhancement] Allow overriding settings for the
+  `hastexo_guacamole_client` from a configuration file by defining
+  it as `HASTEXO_GUACAMOLE_CFG`.
+
 Version 5.0.0rc0 (2021-02-02)
 -----------------------------
 * [BREAKING CHANGE] Replace Guacamole servlet with a Django ASGI


### PR DESCRIPTION
Allow overriding hastexo_guacamole_client settings.py values from
a configuration file by defining the file as `HASTEXO_GUACAMOLE_CFG`