### PR TITLE
Fix `Stack.DoesNotExist` error when deleting learner state

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+Unreleased
+-------------------------
+* [Bug fix] When deleting learner state, the `stack_name` value
+  gets wiped out. If we then try to update the stack (for example
+  via `keepalive`) we get `Stack.DoesNotExist` error. Check if
+  `stack_name` has a value before attempting to update and if not,
+  set it again.
+
 Version 4.1.10 (2021-02-11)
 -------------------------
 * [Bug fix] Implement more of `ScorableXBlockMixin` functionality

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -514,6 +514,12 @@ class HastexoXBlock(XBlock,
             # delete_age value in settings is in days, convert to seconds
             return settings.get("delete_age", 14) * 86400
 
+    def get_stack_name(self):
+        # Get the course id and anonymous user id, and derive the stack name
+        # from them
+        course_id, student_id = self.get_block_ids()
+        return "%s_%s_%s" % (course_id.course, course_id.run, student_id)
+
     def student_view(self, context=None):
         """
         The primary view of the HastexoXBlock, shown to students when viewing
@@ -526,7 +532,7 @@ class HastexoXBlock(XBlock,
         # from them
         course_id, student_id = self.get_block_ids()
         self.stack_run = "%s_%s" % (course_id.course, course_id.run)
-        self.stack_name = "%s_%s" % (self.stack_run, student_id)
+        self.stack_name = self.get_stack_name()
 
         frag = Fragment()
 
@@ -678,6 +684,10 @@ class HastexoXBlock(XBlock,
         in a transaction.
         """
         course_id, student_id = self.get_block_ids()
+        if not self.stack_name:
+            # Stack name can be occasionally end up being empty (after deleting
+            # learners state for example). If so, set it again.
+            self.stack_name = self.get_stack_name()
         update_stack(self.stack_name, course_id, student_id, data)
 
     def get_stack(self, prop=None):

--- a/tests/unit/test_hastexo.py
+++ b/tests/unit/test_hastexo.py
@@ -908,3 +908,17 @@ class TestHastexoXBlock(TestCase):
     def test_keepalive(self):
         self.init_block()
         self.call_handler("keepalive", data={})
+
+    def test_get_stack_name_on_update(self):
+        self.init_block()
+        stack_name = self.block.stack_name
+        self.block.stack_name = None
+        self.assertIsNone(self.block.stack_name)
+
+        self.block.get_stack_name = Mock()
+        self.block.get_stack_name.return_value = stack_name
+
+        self.block.update_stack(data={})
+        self.block.get_stack_name.assert_called()
+        self.assertIsNotNone(self.block.stack_name)
+        self.assertEqual(self.block.stack_name, stack_name)


### PR DESCRIPTION
When deleting learner state, the `stack_name` value
gets wiped out. If we then try to update the stack (for example
via `keepalive`) we get `Stack.DoesNotExist` error. Check if
`stack_name` has a value before attempting to update and if not,
set it again.