### PR TITLE
WIP: retry remote_exec on SSHException

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version:
+          - 3.5
+          - 3.8
 
     steps:
     - name: Check out code

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
-envlist = py{35,36,37,38}-xblock{13,14},flake8
+envlist = py{35,38}-xblock{13,14},flake8
 
 [gh-actions]
 python =
     3.5: py35,flake8
-    3.6: py36,flake8
-    3.7: py37,flake8
     3.8: py38,flake8
 
 [flake8]
@@ -28,10 +26,7 @@ deps =
     xblock13: XBlock>=1.3,<1.4
     xblock14: XBlock>=1.4,<1.5
 commands =
-    py35: python run_tests.py []
-    py36: python run_tests.py []
-    py37: python run_tests.py []
-    py38: python run_tests.py []
+    python run_tests.py []
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
This is an attempt to make `remote_exec()` more robust against transient network errors: if we get a `socket.error`, like errno 104 (Connection reset by peer), simply retry the SSH call up to two times.