### PR TITLE
Retry on Paramiko socket timeout

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version:
+          - 3.5
+          - 3.8
 
     steps:
     - name: Check out code

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+---------------------------
+* [Bug fix] Make Paramiko SSH connections more robust against socket
+  timeouts (and retry the connection if it runs into one).
+
 Version 5.0.1 (2021-03-04)
 ---------------------------
 * [DEPRECATION] As of this release, the previous implementation that

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ To deploy the hastexo XBlock:
             "delete_age": 14,
             "delete_attempts": 3,
             "delete_task_timeout": 900,
+            "ssh_connect_timeout": 10,
             "sleep_timeout": 10,
             "js_timeouts": {
                 "status": 15000,

--- a/requirements/setup.txt
+++ b/requirements/setup.txt
@@ -1,3 +1,3 @@
 -r base.txt
-setuptools-scm
+setuptools-scm<6
 bumpversion

--- a/setup.py
+++ b/setup.py
@@ -75,5 +75,5 @@ setup(
                                "public",
                                "management",
                                "migrations"]),
-    setup_requires=['setuptools-scm'],
+    setup_requires=['setuptools-scm<6'],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
-envlist = py{35,36,37,38}-xblock{13,14},flake8
+envlist = py{35,38}-xblock{13,14},flake8
 
 [gh-actions]
 python =
     3.5: py35,flake8
-    3.6: py36,flake8
-    3.7: py37,flake8
     3.8: py38,flake8
 
 [flake8]
@@ -28,10 +26,7 @@ deps =
     xblock13: XBlock>=1.3,<1.4
     xblock14: XBlock>=1.4,<1.5
 commands =
-    py35: python run_tests.py []
-    py36: python run_tests.py []
-    py37: python run_tests.py []
-    py38: python run_tests.py []
+    python run_tests.py []
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
When we don't get an SSH connection from Paramiko immediately, we don't want to wait forever until we hit the task timeout. Instead, we define a shorter timeout, `ssh_connect_timeout`, defaulting to 10 seconds, and use that to set a socket timeout option with the Paramiko [`connect()`](http://docs.paramiko.org/en/stable/api/client.html#paramiko.client.SSHClient.connect) call.

If we fail to establish a connection within that time, we hit the [`socket.timeout`](https://docs.python.org/3/library/socket.html#socket.timeout) error, which we then catch in order to retry the connection.