### PR TITLE
Fix test requirements for CVE-2021-3281

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+---------------------------
+* [Bug fix] Update test dependencies to address
+  [CVE-2021-3281](https://nvd.nist.gov/vuln/detail/CVE-2021-3281).
+
 Version 5.0.2 (2021-03-17)
 ---------------------------
 * [Bug fix] Make Paramiko SSH connections more robust against socket

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 -r base.txt
 
 # These package versions must be kept in sync with edx-platform as much as possible.
-django>=2.2.16,<3.0
+django>=2.2.18,<3.0
 celery>=3.1.25,<4.0
 xblock-utils==2.1.1
 six==1.14.0


### PR DESCRIPTION
Django 2.x releases prior to 2.2.18 have an insecure `django.utils.archive.extract method`. We only install Django in testing, and the problem appears to affect only `django-admin startproject` and `manage.py startapp` which are obviously never used in day-to-day operations, but we should still fix the dependency.

Bump the django dependency in `requirements/test.txt` to `>=2.2.18,<3.0`.

Reference:
https://github.com/advisories/GHSA-fvgf-6h6h-3322