### PR TITLE
Add logging to the hastexo.provider module

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@ Unreleased
 ---------------------------
 * [Bug fix] Update test dependencies to address
   [CVE-2021-3281](https://nvd.nist.gov/vuln/detail/CVE-2021-3281).
+* [Enhancement] Add logging to provider actions, to make interactions
+  with cloud platforms more easily traceable.
 
 Version 5.0.2 (2021-03-17)
 ---------------------------

--- a/hastexo/tasks.py
+++ b/hastexo/tasks.py
@@ -159,6 +159,7 @@ class LaunchStackTask(HastexoTask):
         self.providers = []
         for provider in stack.providers:
             p = Provider.init(provider["name"])
+            p.set_logger(logger)
             p.set_capacity(provider["capacity"])
 
             template = read_from_contentstore(
@@ -646,6 +647,7 @@ class SuspendStackTask(HastexoTask):
 
     def suspend_stack(self, stack):
         provider = Provider.init(stack.provider)
+        provider.set_logger(logger)
         provider_stack = provider.get_stack(stack.name)
 
         if provider_stack["status"] in UP_STATES + (SUSPEND_FAILED,):
@@ -729,6 +731,7 @@ class DeleteStackTask(HastexoTask):
         settings = get_xblock_settings()
         attempts = settings.get("delete_attempts", 3)
         provider = Provider.init(stack.provider)
+        provider.set_logger(logger)
         provider_stack = provider.get_stack(stack.name)
         attempt = 0
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,9 @@ include =
 
 [coverage:report]
 precision = 2
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError
 
 [testenv]
 deps =


### PR DESCRIPTION
The `hastexo.provider` module previously had no logging at all. While the creation, suspension, and resumption of stacks was well covered in other places (specifically, the `hastexo.tasks` module), some other actions were not, in particular:

* Rebooting an OpenStack Nova VM when a stack exposed the `reboot_on_resume` output.
* Stopping and starting Google Cloud servers when "suspending" and "resuming" deployments (which we use since "real" suspend and resume for instances are still [beta features](https://cloud.google.com/compute/docs/instances/suspend-resume-instance).

These actions would only be logged if they failed (which would cause a `ProviderException`, handled up the stack), but not if they
succeeded. This complicated tracing and debugging.

Thus:
* Add informative log messages in `hastexo.provider`.
* Add a facility to override the default logger in `hastexo.provider`, by adding `set_logger()` and `reset_logger()` methods to the `Provider` class.
* When instances of the `Provider` class are used from `hastexo.tasks`, set the logger to the task logger so that the provider's actions can be more easily correlated with the task that invoked them.