### PR TITLE
Refactor closing ssh connections

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+Unreleased
+--------------------------
+* [Bug fix] Refactor closing ssh connection in `finally` blocks.
+
 Version 5.0.5 (2021-03-30)
 --------------------------
 * [Bug fix] Add `null=True` for `key` and `password` in the Stack


### PR DESCRIPTION
It may happen that a target stack is unexpectedly unavailable, either
due to a networking problem or the target VM is killed outside of the
XBlock's own functionality.

When that happens, a task can hit its timeout, fail to create an
ssh connection and leave the `ssh` variable undefined.

This will cause the SSH connection cleanup to break in the finally
clause.

Check if an ssh connection exist before trying to close one to
avoid any unhandled exceptions thrown in this scenario.