### PR TITLE
Make the reset warning more verbose

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.5
           - 3.8
 
     steps:

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 Unreleased
 -------------------------
+* [Enhancement] Display the "check progress" button (if enabled) in
+  blue, to provide greater contrast to the red reset button.
 * [Enhancement] Make the warning learners see when they reset a lab
   more verbose. Also, add a specific warning in case the XBlock is
   being displayed in a timed exam, indicating that the exam timer will

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+Unreleased
+-------------------------
+* [Enhancement] Make the warning learners see when they reset a lab
+  more verbose. Also, add a specific warning in case the XBlock is
+  being displayed in a timed exam, indicating that the exam timer will
+  continue to run while the lab is being reset.
+
 Version 5.0.8 (2021-04-21)
 -------------------------
 * [Bug fix] Revert previous unsuccessful attempt to refactor Celery

--- a/hastexo/public/css/main.css
+++ b/hastexo/public/css/main.css
@@ -117,6 +117,10 @@
     margin: 0 0 0.5em 0!important;
 }
 
+.inner .exam-warning {
+    display: none;
+}
+
 .hints_title {
     color: red;
     padding-top: 0.5em;

--- a/hastexo/public/css/main.css
+++ b/hastexo/public/css/main.css
@@ -3,6 +3,7 @@
 }
 
 .buttons .check {
+    color: blue;
     display: none;
 }
 

--- a/hastexo/public/js/main.js
+++ b/hastexo/public/js/main.js
@@ -593,6 +593,11 @@ function HastexoXBlock(runtime, element, configuration) {
     var reset_dialog = function() {
         var dialog = $('#reset_dialog');
 
+        /* add an extra warning text for timed exams */
+        if ($(".exam-timer-clock")[0]){
+            $('.exam-warning').css('display', 'inline-block');
+        }
+
         dialog.find('input.cancel').one('click', function() {
             $.dialog.close();
         });

--- a/hastexo/static/html/main.html
+++ b/hastexo/static/html/main.html
@@ -67,8 +67,15 @@
   <div class="dialog" id="reset_dialog">
     <div class="inner">
       <h1>Are you sure?</h1>
-      <p class="message">Resetting will return your lab environment to a pristine state.<br/>
-	After you reset, you will need to retrace your steps up to this point.<br/>
+      <p class="message">Resetting will return your lab environment to
+	a pristine state.<br/>
+	This may take several minutes to
+	complete.
+	<span class="exam-warning">In a timed exam, the timer will
+	  continue to run while your environment is being
+	  reset.</span><br/>
+	After you reset, you will need to retrace your steps up to
+	this point.<br/>
 	You cannot undo this action.</p>
       <p class="buttons">
         <input type="button" class="reset" value="Reset"></input>


### PR DESCRIPTION
* Add a reminder that resetting a lab will take several minutes.
* Add an additional sentence (set to `display: none;`) reminding a learner that if they are in a middle of an exam, the exam timer will   continue to run while they are resetting.

What's still left here is some JavaScript magic that flips the `display` property when there is an exam timer (`<span class="exam-timer-clock">`) somewhere on the page.