### PR TITLE
Register Celery tasks to an app

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+-------------------------
+* [Bug fix] Refactor Celery tasks logic to define a Celery app
+  and register our class based tasks to that app.
+
 Version 5.0.6 (2021-04-07)
 --------------------------
 * [Bug fix] Refactor closing ssh connection in `finally` blocks.

--- a/hastexo/celery.py
+++ b/hastexo/celery.py
@@ -1,0 +1,7 @@
+from celery import Celery
+
+
+app = Celery('hastexo')
+
+app.config_from_object('django.conf:settings')
+app.autodiscover_tasks()

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -699,7 +699,7 @@ class HastexoXBlock(XBlock,
         soft_time_limit = self.get_launch_timeout(settings)
         hard_time_limit = soft_time_limit + 30
 
-        return LaunchStackTask().apply_async(
+        return LaunchStackTask.apply_async(
             kwargs=kwargs,
             expires=soft_time_limit,
             soft_time_limit=soft_time_limit,
@@ -707,7 +707,7 @@ class HastexoXBlock(XBlock,
         )
 
     def launch_stack_task_result(self, task_id):
-        return LaunchStackTask().AsyncResult(task_id)
+        return LaunchStackTask.AsyncResult(task_id)
 
     @XBlock.json_handler
     @transaction.atomic
@@ -877,7 +877,7 @@ class HastexoXBlock(XBlock,
         self.update_stack({"port": int(data.get("port"))})
 
     def check_progress_task(self, soft_time_limit, **kwargs):
-        task = CheckStudentProgressTask()
+        task = CheckStudentProgressTask
         time_limit = soft_time_limit + 30
         result = task.apply_async(
             kwargs=kwargs,
@@ -889,7 +889,7 @@ class HastexoXBlock(XBlock,
         return result
 
     def check_progress_task_result(self, check_id):
-        return CheckStudentProgressTask().AsyncResult(check_id)
+        return CheckStudentProgressTask.AsyncResult(check_id)
 
     @XBlock.json_handler
     def get_check_status(self, data, suffix=''):

--- a/hastexo/jobs.py
+++ b/hastexo/jobs.py
@@ -95,7 +95,7 @@ class SuspenderJob(AbstractJob):
         kwargs = {
             "stack_id": stack.id
         }
-        SuspendStackTask().apply_async(
+        SuspendStackTask.apply_async(
             kwargs=kwargs,
             soft_time_limit=soft_time_limit,
             time_limit=hard_time_limit,
@@ -185,7 +185,7 @@ class ReaperJob(AbstractJob):
         kwargs = {
             "stack_id": stack.id
         }
-        DeleteStackTask().apply_async(
+        DeleteStackTask.apply_async(
             kwargs=kwargs,
             soft_time_limit=soft_time_limit,
             time_limit=hard_time_limit,

--- a/hastexo/tasks.py
+++ b/hastexo/tasks.py
@@ -19,6 +19,7 @@ from tenacity import (
     before_sleep_log,
 )
 
+from .celery import app
 from .models import Stack
 from .provider import Provider, ProviderException
 from .common import (
@@ -609,6 +610,9 @@ class LaunchStackTask(HastexoTask):
         return check_data
 
 
+LaunchStackTask = app.register_task(LaunchStackTask())
+
+
 class SuspendStackTask(HastexoTask):
     """
     Suspends a stack.
@@ -686,6 +690,9 @@ class SuspendStackTask(HastexoTask):
                          provider_stack["status"])
 
         return provider_stack["status"]
+
+
+SuspendStackTask = app.register_task(SuspendStackTask())
 
 
 class DeleteStackTask(HastexoTask):
@@ -805,6 +812,9 @@ class DeleteStackTask(HastexoTask):
         return provider_stack["status"]
 
 
+DeleteStackTask = app.register_task(DeleteStackTask())
+
+
 class CheckStudentProgressTask(HastexoTask):
     """
     Check student progress by running a set of scripts via SSH.
@@ -864,3 +874,6 @@ class CheckStudentProgressTask(HastexoTask):
             'total': len(self.tests),
             'errors': errors
         }
+
+
+CheckStudentProgressTask = app.register_task(CheckStudentProgressTask())

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -62,10 +62,10 @@ class TestHastexoJobs(TestCase):
             self.addCleanup(patcher.stop)
 
     def get_suspend_task_mock(self):
-        return self.mocks["SuspendStackTask"].return_value
+        return self.mocks["SuspendStackTask"]
 
     def get_delete_task_mock(self):
-        return self.mocks["DeleteStackTask"].return_value
+        return self.mocks["DeleteStackTask"]
 
     def test_dont_suspend_stack_with_no_provider(self):
         # Setup

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -129,6 +129,7 @@ class HastexoTestCase(TestCase):
             "read_from_contentstore": patch(
                 "hastexo.tasks.read_from_contentstore"),
             "remote_exec": patch("hastexo.tasks.remote_exec"),
+            "celery_app": patch("hastexo.celery.app")
         }
         self.mocks = {}
         for mock_name, patcher in patchers.items():
@@ -184,8 +185,11 @@ class TestLaunchStackTask(HastexoTestCase):
             self.stacks["CREATE_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -226,13 +230,16 @@ class TestLaunchStackTask(HastexoTestCase):
             self.stacks["CREATE_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Mock OperationalError 2 times with Stack.objects.filter()
         with patch("hastexo.models.Stack.objects.filter") as filter_patch:
             filter_patch.side_effect = [OperationalError,
                                         OperationalError,
                                         Stack.objects]
             # Run
-            LaunchStackTask().run(**self.kwargs)
+            LaunchStackTask.run(**self.kwargs)
 
         # The filter() method would have to be called 3 times
         # (2 failures with an OperationalError, then 1 success).
@@ -276,6 +283,9 @@ class TestLaunchStackTask(HastexoTestCase):
             self.stacks["CREATE_FAILED"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Mock OperationalError 3 times with Stack.objects.filter()
         with patch("hastexo.models.Stack.objects.filter") as filter_patch:
             filter_patch.side_effect = [OperationalError,
@@ -283,7 +293,7 @@ class TestLaunchStackTask(HastexoTestCase):
                                         OperationalError]
             # Run
             with self.assertRaises(OperationalError):
-                LaunchStackTask().run(**self.kwargs)
+                LaunchStackTask.run(**self.kwargs)
 
             # The filter() method would have to be called 3 times.
             self.assertEqual(filter_patch.call_count, 3)
@@ -307,8 +317,11 @@ class TestLaunchStackTask(HastexoTestCase):
             self.stacks["CREATE_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -332,8 +345,11 @@ class TestLaunchStackTask(HastexoTestCase):
             self.stacks["CREATE_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -350,8 +366,11 @@ class TestLaunchStackTask(HastexoTestCase):
                 ProviderException()
             ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -377,8 +396,11 @@ class TestLaunchStackTask(HastexoTestCase):
             self.stacks["CREATE_COMPLETE"],
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -399,8 +421,11 @@ class TestLaunchStackTask(HastexoTestCase):
         })
         self.kwargs["reset"] = True
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -423,8 +448,11 @@ class TestLaunchStackTask(HastexoTestCase):
             "status": "SUSPEND_COMPLETE"
         })
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -454,8 +482,11 @@ class TestLaunchStackTask(HastexoTestCase):
             self.stacks["CREATE_COMPLETE"],
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -479,8 +510,11 @@ class TestLaunchStackTask(HastexoTestCase):
             SoftTimeLimitExceeded()
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -507,8 +541,11 @@ class TestLaunchStackTask(HastexoTestCase):
             "status": "SUSPEND_COMPLETE"
         })
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -523,10 +560,13 @@ class TestLaunchStackTask(HastexoTestCase):
         self.providers[0].pop("capacity")
         self.update_stack({"providers": self.providers})
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Assert LaunchStackTask() fails if capacity is not defined
         # for a provider.
         with self.assertRaises(KeyError):
-            LaunchStackTask().run(**self.kwargs)
+            LaunchStackTask.run(**self.kwargs)
 
     def test_infinite_capacity(self):
         # Setup
@@ -549,8 +589,11 @@ class TestLaunchStackTask(HastexoTestCase):
             student_id = "student_%d" % i
             self.create_stack(name, self.course_id, student_id, data)
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -578,8 +621,11 @@ class TestLaunchStackTask(HastexoTestCase):
             self.stacks["CREATE_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -616,8 +662,11 @@ class TestLaunchStackTask(HastexoTestCase):
             student_id = "student_%d" % i
             self.create_stack(name, self.course_id, student_id, data)
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -649,8 +698,11 @@ class TestLaunchStackTask(HastexoTestCase):
                 self.create_stack(name, self.course_id, student_id, data)
         self.update_stack({"providers": self.providers})
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -678,8 +730,11 @@ class TestLaunchStackTask(HastexoTestCase):
             self.stacks["CREATE_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -707,8 +762,11 @@ class TestLaunchStackTask(HastexoTestCase):
             SoftTimeLimitExceeded
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -724,8 +782,11 @@ class TestLaunchStackTask(HastexoTestCase):
             SoftTimeLimitExceeded
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -744,8 +805,11 @@ class TestLaunchStackTask(HastexoTestCase):
                 ProviderException()
             ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -779,8 +843,11 @@ class TestLaunchStackTask(HastexoTestCase):
         })
         self.kwargs["reset"] = True
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -803,8 +870,11 @@ class TestLaunchStackTask(HastexoTestCase):
         ]
         self.kwargs["reset"] = True
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -829,8 +899,11 @@ class TestLaunchStackTask(HastexoTestCase):
         })
         self.kwargs["reset"] = True
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -853,8 +926,11 @@ class TestLaunchStackTask(HastexoTestCase):
             "status": "SUSPEND_COMPLETE"
         })
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -889,12 +965,15 @@ class TestLaunchStackTask(HastexoTestCase):
             "status": "SUSPEND_COMPLETE"
         })
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Mock OperationalError 2 times
         with patch.object(Stack, 'save', side_effect=[OperationalError,
                                                       OperationalError,
                                                       None]) as save_patch:
             # Run
-            LaunchStackTask().run(**self.kwargs)
+            LaunchStackTask.run(**self.kwargs)
 
             # The save() method would have to be called 3 times (2
             # failures with an OperationalError, then 1 success).
@@ -927,6 +1006,9 @@ class TestLaunchStackTask(HastexoTestCase):
             "status": "SUSPEND_COMPLETE"
         })
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Mock OperationalError 3 times
         with patch.object(
             Stack, 'save', side_effect=[OperationalError,
@@ -934,7 +1016,7 @@ class TestLaunchStackTask(HastexoTestCase):
                                         OperationalError]) as save_patch:
             # Run
             with self.assertRaises(OperationalError):
-                LaunchStackTask().run(**self.kwargs)
+                LaunchStackTask.run(**self.kwargs)
 
             # The save() method would have to be called 3 times.
             self.assertEqual(save_patch.call_count, 3)
@@ -968,8 +1050,11 @@ class TestLaunchStackTask(HastexoTestCase):
             "status": "SUSPEND_COMPLETE"
         })
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -993,8 +1078,11 @@ class TestLaunchStackTask(HastexoTestCase):
             "status": "SUSPEND_COMPLETE"
         })
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1018,8 +1106,11 @@ class TestLaunchStackTask(HastexoTestCase):
             "hook_events": {},
         })
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1044,8 +1135,11 @@ class TestLaunchStackTask(HastexoTestCase):
         })
         self.mocks["remote_exec"].side_effect = Exception()
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1070,8 +1164,11 @@ class TestLaunchStackTask(HastexoTestCase):
         })
         self.mocks["remote_exec"].side_effect = RemoteExecException
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1093,8 +1190,11 @@ class TestLaunchStackTask(HastexoTestCase):
             "status": "SUSPEND_COMPLETE"
         })
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1115,8 +1215,11 @@ class TestLaunchStackTask(HastexoTestCase):
             "status": "SUSPEND_COMPLETE"
         })
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1141,8 +1244,11 @@ class TestLaunchStackTask(HastexoTestCase):
             "status": "SUSPEND_COMPLETE"
         })
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1166,8 +1272,11 @@ class TestLaunchStackTask(HastexoTestCase):
         self.providers = [self.providers[0]]
         self.update_stack({"providers": self.providers})
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1190,8 +1299,11 @@ class TestLaunchStackTask(HastexoTestCase):
         self.providers = [self.providers[0]]
         self.update_stack({"providers": self.providers})
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1211,8 +1323,11 @@ class TestLaunchStackTask(HastexoTestCase):
         self.mocks["ssh_to"].side_effect = Exception()
         self.update_stack({"provider": self.providers[0]["name"]})
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1234,8 +1349,11 @@ class TestLaunchStackTask(HastexoTestCase):
         ]
         self.update_stack({"provider": self.providers[0]["name"]})
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1252,8 +1370,11 @@ class TestLaunchStackTask(HastexoTestCase):
         self.mocks["ssh_to"].side_effect = Exception()
         self.update_stack({"provider": self.providers[0]["name"]})
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1271,8 +1392,11 @@ class TestLaunchStackTask(HastexoTestCase):
         system.side_effect = SoftTimeLimitExceeded
         self.update_stack({"provider": self.providers[0]["name"]})
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1290,8 +1414,11 @@ class TestLaunchStackTask(HastexoTestCase):
         self.mocks["ssh_to"].side_effect = SoftTimeLimitExceeded
         self.update_stack({"provider": self.providers[0]["name"]})
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1317,8 +1444,11 @@ class TestLaunchStackTask(HastexoTestCase):
         self.protocol = "rdp"
         self.update_stack({"protocol": self.protocol})
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1348,8 +1478,11 @@ class TestLaunchStackTask(HastexoTestCase):
             "port": self.port,
         })
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1371,8 +1504,11 @@ class TestLaunchStackTask(HastexoTestCase):
             "status": "SUSPEND_COMPLETE"
         })
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1391,8 +1527,11 @@ class TestLaunchStackTask(HastexoTestCase):
             SoftTimeLimitExceeded
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1417,8 +1556,11 @@ class TestLaunchStackTask(HastexoTestCase):
             "status": "SUSPEND_COMPLETE"
         })
 
+        self.mocks["celery_app"].register_task.return_value = \
+            LaunchStackTask
+
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1442,8 +1584,11 @@ class TestSuspendStackTask(HastexoTestCase):
             self.stacks["SUSPEND_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            SuspendStackTask
+
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1473,8 +1618,11 @@ class TestSuspendStackTask(HastexoTestCase):
             self.stacks["SUSPEND_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            SuspendStackTask
+
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1505,8 +1653,11 @@ class TestSuspendStackTask(HastexoTestCase):
             self.stacks["SUSPEND_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            SuspendStackTask
+
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1535,8 +1686,11 @@ class TestSuspendStackTask(HastexoTestCase):
             self.stacks["SUSPEND_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            SuspendStackTask
+
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1567,8 +1721,11 @@ class TestSuspendStackTask(HastexoTestCase):
             self.stacks["SUSPEND_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            SuspendStackTask
+
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1595,8 +1752,11 @@ class TestSuspendStackTask(HastexoTestCase):
             self.stacks["DELETE_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            SuspendStackTask
+
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1618,8 +1778,11 @@ class TestSuspendStackTask(HastexoTestCase):
             self.stacks["RESUME_FAILED"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            SuspendStackTask
+
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1639,8 +1802,11 @@ class TestSuspendStackTask(HastexoTestCase):
         provider = self.mock_providers[0]
         provider.get_stack.side_effect = Exception()
 
+        self.mocks["celery_app"].register_task.return_value = \
+            SuspendStackTask
+
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1662,8 +1828,11 @@ class TestSuspendStackTask(HastexoTestCase):
         ]
         provider.suspend_stack.side_effect = SoftTimeLimitExceeded
 
+        self.mocks["celery_app"].register_task.return_value = \
+            SuspendStackTask
+
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1692,8 +1861,11 @@ class TestDeleteStackTask(HastexoTestCase):
             self.stacks["DELETE_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            DeleteStackTask
+
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1724,8 +1896,11 @@ class TestDeleteStackTask(HastexoTestCase):
             self.stacks["DELETE_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            DeleteStackTask
+
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1756,8 +1931,11 @@ class TestDeleteStackTask(HastexoTestCase):
             self.stacks["DELETE_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            DeleteStackTask
+
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1785,8 +1963,11 @@ class TestDeleteStackTask(HastexoTestCase):
             self.stacks["DELETE_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            DeleteStackTask
+
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1814,8 +1995,11 @@ class TestDeleteStackTask(HastexoTestCase):
             self.stacks["DELETE_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            DeleteStackTask
+
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1848,8 +2032,11 @@ class TestDeleteStackTask(HastexoTestCase):
             self.stacks["DELETE_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            DeleteStackTask
+
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1880,8 +2067,11 @@ class TestDeleteStackTask(HastexoTestCase):
             self.stacks["DELETE_COMPLETE"]
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            DeleteStackTask
+
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1914,8 +2104,11 @@ class TestDeleteStackTask(HastexoTestCase):
             self.stacks["DELETE_COMPLETE"],
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            DeleteStackTask
+
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1945,8 +2138,11 @@ class TestDeleteStackTask(HastexoTestCase):
             Exception(""),
         ]
 
+        self.mocks["celery_app"].register_task.return_value = \
+            DeleteStackTask
+
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1971,8 +2167,11 @@ class TestDeleteStackTask(HastexoTestCase):
         ]
         provider.delete_stack.side_effect = SoftTimeLimitExceeded
 
+        self.mocks["celery_app"].register_task.return_value = \
+            DeleteStackTask
+
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -2008,8 +2207,11 @@ class TestCheckStudentProgressTask(HastexoTestCase):
             "stack_user_name": self.stack_user_name
         }
 
+        self.mocks["celery_app"].register_task.return_value = \
+            CheckStudentProgressTask
+
         # Run
-        res = CheckStudentProgressTask().run(**kwargs)
+        res = CheckStudentProgressTask.run(**kwargs)
 
         # Assertions
         self.assertEqual(res["status"], "CHECK_PROGRESS_COMPLETE")
@@ -2032,8 +2234,11 @@ class TestCheckStudentProgressTask(HastexoTestCase):
             "stack_user_name": self.stack_user_name
         }
 
+        self.mocks["celery_app"].register_task.return_value = \
+            CheckStudentProgressTask
+
         # Run
-        res = CheckStudentProgressTask().run(**kwargs)
+        res = CheckStudentProgressTask.run(**kwargs)
 
         # Assertions
         self.assertEqual(res["status"], "CHECK_PROGRESS_COMPLETE")
@@ -2077,8 +2282,11 @@ class TestCheckStudentProgressTask(HastexoTestCase):
             "stack_user_name": self.stack_user_name
         }
 
+        self.mocks["celery_app"].register_task.return_value = \
+            CheckStudentProgressTask
+
         # Run
-        res = CheckStudentProgressTask().run(**kwargs)
+        res = CheckStudentProgressTask.run(**kwargs)
 
         # Assertions
         self.assertEqual(res["status"], "CHECK_PROGRESS_COMPLETE")


### PR DESCRIPTION
Starting with Celery version 4.0 the Task base class no longer
automatically register tasks (https://docs.celeryproject.org/en/4.0/whatsnew-4.0.html#the-task-base-class-no-longer-automatically-register-tasks)
and we will need to register our class based tasks "manually".