### PR TITLE
Register Celery tasks to lms.celery:APP

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+Unreleased
+-------------------------
+* [Bug fix] Attempt to register Celery tasks to `lms.celery:APP`
+
 Version 5.0.7 (2021-04-16)
 -------------------------
 * [Bug fix] Refactor Celery tasks logic to define a Celery app

--- a/fake/lms/celery.py
+++ b/fake/lms/celery.py
@@ -1,0 +1,4 @@
+from celery import Celery
+
+
+APP = Celery('proj')

--- a/hastexo/celery.py
+++ b/hastexo/celery.py
@@ -1,7 +1,0 @@
-from celery import Celery
-
-
-app = Celery('hastexo')
-
-app.config_from_object('django.conf:settings')
-app.autodiscover_tasks()

--- a/hastexo/tasks.py
+++ b/hastexo/tasks.py
@@ -19,7 +19,8 @@ from tenacity import (
     before_sleep_log,
 )
 
-from .celery import app
+from lms.celery import APP
+
 from .models import Stack
 from .provider import Provider, ProviderException
 from .common import (
@@ -610,7 +611,7 @@ class LaunchStackTask(HastexoTask):
         return check_data
 
 
-LaunchStackTask = app.register_task(LaunchStackTask())
+LaunchStackTask = APP.register_task(LaunchStackTask())
 
 
 class SuspendStackTask(HastexoTask):
@@ -692,7 +693,7 @@ class SuspendStackTask(HastexoTask):
         return provider_stack["status"]
 
 
-SuspendStackTask = app.register_task(SuspendStackTask())
+SuspendStackTask = APP.register_task(SuspendStackTask())
 
 
 class DeleteStackTask(HastexoTask):
@@ -812,7 +813,7 @@ class DeleteStackTask(HastexoTask):
         return provider_stack["status"]
 
 
-DeleteStackTask = app.register_task(DeleteStackTask())
+DeleteStackTask = APP.register_task(DeleteStackTask())
 
 
 class CheckStudentProgressTask(HastexoTask):
@@ -876,4 +877,4 @@ class CheckStudentProgressTask(HastexoTask):
         }
 
 
-CheckStudentProgressTask = app.register_task(CheckStudentProgressTask())
+CheckStudentProgressTask = APP.register_task(CheckStudentProgressTask())

--- a/run_tests.py
+++ b/run_tests.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
 
     from django.conf import settings
     settings.DEBUG = True
-    settings.INSTALLED_APPS += ("hastexo", "common.djangoapps.student", )
+    settings.INSTALLED_APPS += ("hastexo", "common.djangoapps.student", "lms")
 
     from django.core.management import execute_from_command_line
     args = sys.argv[1:]

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -129,7 +129,7 @@ class HastexoTestCase(TestCase):
             "read_from_contentstore": patch(
                 "hastexo.tasks.read_from_contentstore"),
             "remote_exec": patch("hastexo.tasks.remote_exec"),
-            "celery_app": patch("hastexo.celery.app")
+            "celery_app": patch("lms.celery.APP")
         }
         self.mocks = {}
         for mock_name, patcher in patchers.items():


### PR DESCRIPTION
Our `hastexo.tasks` are not being registered when running with a
newer version of Celery(4.4.7). Attempt to register the tasks to the LMS
Celery APP.