### PR TITLE
Fix dependency updates

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+-------------------------
+* [Bug fix] Add constraints to `dogpile.cache` and `cliff`, so that our
+  OpenStack client libraries will not have dependency conflicts.
+
 Version 5.0.10 (2021-04-26)
 -------------------------
 * [Enhancement] Relax version constraints in `requirements/base.txt`

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,6 @@
 apscheduler>=3.5.1,<3.8
+cliff<3.4.0
+dogpile.cache<1.0.0
 google-auth>=1.4.1,<1.5
 google-api-python-client>=1.7.7,<1.8
 keystoneauth1>=3.13.0,<3.18


### PR DESCRIPTION
When running the OpenStack libraries on the Train release versions,
we ended up having dependency conflicts with `edx-platform`, that
sets `stevedore==1.32.0`.

Add constraints to `dogpile.cache`, which is a requirement for
`openstacksdk` and adds `stevedore>=3.0.0` in version 1.0.0.

Add constraints to `cliff` which is a requirement for python-heatclient
and adds `stevedore>=2.0.1` in version 3.4.0.