### PR TITLE
Speed up progress checks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+-------------------------
+* [Enhancement] Speed up progress checks by reducing the sleep time when
+  waiting for a remote execution of a command to finish.
+
 Version 5.0.11 (2021-05-10)
 -------------------------
 * [Bug fix] Add constraints to `dogpile.cache` and `cliff`, so that our

--- a/hastexo/common.py
+++ b/hastexo/common.py
@@ -346,7 +346,6 @@ def remote_exec(ssh, script, params=None, reuse_sftp=None):
     # Wait for it to complete.
     settings = get_xblock_settings()
     timeout = settings.get("remote_exec_timeout", 300)
-    sleep_timeout = settings.get("sleep_timeout", 10)
     try:
         start = time.time()
         while not stdout.channel.exit_status_ready():
@@ -355,7 +354,7 @@ def remote_exec(ssh, script, params=None, reuse_sftp=None):
                              timeout)
                 raise RemoteExecTimeout(error_msg)
 
-            time.sleep(sleep_timeout)
+            time.sleep(1)
     finally:
         # Remove the file
         sftp.remove(script_file)

--- a/hastexo/tasks.py
+++ b/hastexo/tasks.py
@@ -852,6 +852,9 @@ class CheckStudentProgressTask(HastexoTask):
         for test in self.tests:
             try:
                 remote_exec(ssh, test, reuse_sftp=sftp)
+            except RemoteExecTimeout as e:
+                logger.warning("Timeout when running test: %s" % e)
+                raise
             except RemoteExecException as e:
                 msg = e.args[0]
                 hint = msg.decode() if isinstance(msg, bytes) else str(msg)


### PR DESCRIPTION
Reduce the sleep time to 1s when waiting for a remote execution
of a command to finish.

Add an except clause for RemoteExecTimeout so that the timeout
message would be displayed as "Unexpected result" instead of
as a hint to the learner.