### PR TITLE
Improve testing

### DIFF
--- a/requirements/flake8.txt
+++ b/requirements/flake8.txt
@@ -1,2 +1,1 @@
--r base.txt
 flake8

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,9 +11,6 @@ mako==1.1.3
 sqlparse==0.4.1
 web-fragments==0.3.2
 
-# XBlock SDK
--e git://github.com/edx/xblock-sdk.git@master#egg=xblock-sdk==master
-
 # Other XBlocks that are supported as nested elements
 markdown-xblock
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,8 @@ exclude_lines =
 deps =
     -rrequirements/setup.txt
     -rrequirements/test.txt
+    py35: xblock-sdk<0.3
+    py38: xblock-sdk
     xblock13: XBlock>=1.3,<1.4
     xblock14: XBlock>=1.4,<1.5
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ commands =
     python run_tests.py []
 
 [testenv:flake8]
+skip_install = True
 deps =
     -rrequirements/flake8.txt
 commands = flake8


### PR DESCRIPTION
* Make flake8 testing a little faster
* No longer rely on xblock-sdk from GitHub; instead install it from PyPI (picking the correct versions for Python 3.5 and 3.6).