### PR TITLE
Fix RDP connectivity checks for IPv6 stacks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+Unreleased
+-------------------------
+* [Bug fix] Fix RDP connectivity check for IPv6 stacks.
+
 Version 5.0.12 (2021-05-12)
 -------------------------
 * [Enhancement] Speed up progress checks by reducing the sleep time when

--- a/hastexo/tasks.py
+++ b/hastexo/tasks.py
@@ -520,11 +520,11 @@ class LaunchStackTask(HastexoTask):
             port = 3389
 
         connected = False
-        s = socket.socket()
-        s.settimeout(self.get_sleep_timeout())
+        conn = None
         while not connected:
             try:
-                s.connect((stack_ip, port))
+                conn = socket.create_connection((stack_ip, port),
+                                                self.get_sleep_timeout())
             except SoftTimeLimitExceeded:
                 raise
             except Exception:
@@ -532,7 +532,8 @@ class LaunchStackTask(HastexoTask):
             else:
                 connected = True
             finally:
-                s.close()
+                if conn:
+                    conn.close()
 
     def check_stack(self, stack_outputs, was_resumed, provider):
         """

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -155,7 +155,7 @@ class HastexoTestCase(TestCase):
         return self.mocks["ssh_to"]
 
     def get_socket_mock(self):
-        return self.mocks["socket"].socket.return_value
+        return self.mocks["socket"]
 
     def get_stack(self, prop=None):
         return get_stack(self.stack_name, self.course_id, self.student_id,
@@ -1307,7 +1307,7 @@ class TestLaunchStackTask(HastexoTestCase):
             self.stacks["CREATE_COMPLETE"]
         ]
         s = self.get_socket_mock()
-        s.connect.side_effect = [
+        s.create_connection.side_effect = [
             socket.timeout,
             socket.timeout,
             socket.timeout,
@@ -1324,7 +1324,8 @@ class TestLaunchStackTask(HastexoTestCase):
         stack = self.get_stack()
 
         # Assertions
-        s.connect.assert_called_with((self.STACK_IP, 3389))
+        s.create_connection.assert_called_with(
+            (self.STACK_IP, 3389), self.settings['sleep_timeout'])
         self.assertEqual(stack.status, "LAUNCH_TIMEOUT")
 
     def test_dont_wait_forever_for_rdp_on_custom_port(self):
@@ -1334,7 +1335,7 @@ class TestLaunchStackTask(HastexoTestCase):
             self.stacks["CREATE_COMPLETE"]
         ]
         s = self.get_socket_mock()
-        s.connect.side_effect = [
+        s.create_connection.side_effect = [
             socket.timeout,
             socket.timeout,
             socket.timeout,
@@ -1355,7 +1356,8 @@ class TestLaunchStackTask(HastexoTestCase):
         stack = self.get_stack()
 
         # Assertions
-        s.connect.assert_called_with((self.STACK_IP, self.port))
+        s.create_connection.assert_called_with(
+            (self.STACK_IP, self.port), self.settings['sleep_timeout'])
         self.assertEqual(stack.status, "LAUNCH_TIMEOUT")
 
     def test_dont_wait_forever_for_suspension(self):


### PR DESCRIPTION
Our RDP connectivity check is using `socket.socket().connect()`,
which will only try an IPv4 connection and will break for stacks
exposing an IPv6 `public_ip`.
Use `socket.create_connection()` instead, which will try both,
IPv4 and IPv6 connection.