### PR TITLE
Sanitize stack names

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+Unreleased
+-------------------------
+* [Bug fix] Restrict stack names to ASCII characters and digits.
+
 Version 5.0.13 (2021-05-21)
 -------------------------
 * [Bug fix] Fix RDP connectivity check for IPv6 stacks.

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -1,6 +1,8 @@
 import time
 import logging
 import os
+import re
+import string
 import textwrap
 
 from xblock.core import XBlock, XML_NAMESPACES
@@ -518,7 +520,14 @@ class HastexoXBlock(XBlock,
         # Get the course id and anonymous user id, and derive the stack name
         # from them
         course_id, student_id = self.get_block_ids()
-        return "%s_%s_%s" % (course_id.course, course_id.run, student_id)
+        stack_name = "%s_%s_%s" % (course_id.course, course_id.run, student_id)
+
+        # Replace anything in the stack name that is not an ASCII letter or
+        # digit with an underscore
+        replace_pattern = '[^%s%s]' % (string.digits, string.ascii_letters)
+        stack_name = re.sub(re.compile(replace_pattern), '_', stack_name)
+
+        return stack_name
 
     def student_view(self, context=None):
         """

--- a/tests/unit/test_hastexo.py
+++ b/tests/unit/test_hastexo.py
@@ -922,3 +922,17 @@ class TestHastexoXBlock(TestCase):
         self.block.get_stack_name.assert_called()
         self.assertIsNotNone(self.block.stack_name)
         self.assertEqual(self.block.stack_name, stack_name)
+
+    def test_get_stack_name(self):
+        course_id = Mock(course='course', run='run')
+        student_id = 'student'
+        self.block.get_block_ids = Mock(return_value=(course_id, student_id))
+        stack_name = self.block.get_stack_name()
+        self.assertEqual('course_run_student', stack_name)
+
+    def test_get_stack_name_replace_characters(self):
+        course_id = Mock(course='course.name', run='run')
+        student_id = 'student'
+        self.block.get_block_ids = Mock(return_value=(course_id, student_id))
+        stack_name = self.block.get_stack_name()
+        self.assertEqual('course_name_run_student', stack_name)


### PR DESCRIPTION
We build the `stack_name` based on `course_id` and `student_id`.
We also use the same `stack_name` for creating a keypair for the
learner. However, Nova has a list of "unsafe" characters which
will throw an exception, if used in the keypair name.
(https://github.com/openstack/nova/blob/master/nova/compute/api.py#L6396)

Make sure that the `stack_name` consists of only safe characters.