### PR TITLE
WIP: Upload coverage data to Codecov

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -52,10 +52,13 @@ jobs:
         mv coverage-*/.coverage* .
         coverage combine
         coverage html
+        coverage xml
         coverage report
-    - name: Upload coverage report
+    - name: Upload htmlcov archive
       uses: actions/upload-artifact@v2
       with:
         name: htmlcov
         path: htmlcov
         retention-days: 7
+    - name: Upload to codecov
+      uses: codecov/codecov-action@v1


### PR DESCRIPTION
Add the ability to upload coverage data to Codecov, from the
GitHub Actions workflow.