### PR TITLE
Truncate the error message for LaunchError

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+Unreleased
+-------------------------
+* [Bug fix] Truncate the error message for `LaunchError` to fit
+  256 characters and thus, could be added to the `error_msg` field
+  of a `Stack`.
+
 Version 5.0.14 (2021-06-02)
 -------------------------
 * [Bug fix] Make XBlock exports (from Studio or its REST API)

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -46,7 +46,7 @@ class LaunchError(Exception):
     def __init__(self, error_msg):
         super(LaunchError, self).__init__()
 
-        self.error_msg = error_msg
+        self.error_msg = textwrap.shorten(error_msg, width=256)
 
 
 @XBlock.wants('settings')

--- a/tests/unit/test_hastexo.py
+++ b/tests/unit/test_hastexo.py
@@ -848,6 +848,38 @@ class TestHastexoXBlock(TestCase):
         self.assertFalse(mock_launch_stack_task.called)
         self.assertEqual(response["status"], "RESUME_FAILED")
 
+    def test_get_user_stack_status_long_error_message(self):
+        self.init_block()
+        self.update_stack({"status": "SUSPEND_COMPLETE"})
+
+        long_error_message = (
+            "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. "
+            "Aenean commodo ligula eget dolor. Aenean massa. Cum sociis"
+            "natoque penatibus et magnis dis parturient montes, "
+            "nascetur ridiculus mus. Donec quam felis, ultricies nec, "
+            "pellentesque eu, pretium quis, sem. Nulla consequat massa "
+            "quis enim. Donec pede justo, fringilla ve. ")
+        mock_result = Mock()
+        mock_result.id = 'bogus_task_id'
+        mock_result.ready.return_value = True
+        mock_result.successful.return_value = False
+        mock_result.result = long_error_message
+        mock_launch_stack_task = Mock(return_value=mock_result)
+
+        with patch.multiple(
+                self.block,
+                launch_stack_task=mock_launch_stack_task):
+            response = self.call_handler("get_user_stack_status", {})
+
+        self.assertTrue(mock_launch_stack_task.called)
+        self.assertEqual(response["status"], "LAUNCH_ERROR")
+        # assert that the full error message was not set to the
+        # error_msg field.
+        self.assertNotEqual(response["error_msg"], long_error_message)
+        # assert that the error message was shortened to fit 256 characters
+        self.assertTrue(len(response["error_msg"]) <= 256)
+        self.assertIn('[...]', response["error_msg"])
+
     def test_get_check_status(self):
         self.init_block()
         mock_result = Mock()


### PR DESCRIPTION
When a stack launch is unsuccessful, we want to add the error message to
the Stack object's `error_msg` field, which has a limit of 256 characters.
Truncate the `LaunchError` error message to fit that limit.