### PR TITLE
Final round of Stable 4.1 backports

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,8 +22,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install tox tox-gh-actions
+        pip install tox tox-gh-actions tox-pip-version 'setuptools_scm<6'
     - name: Test with tox
+      env:
+        TOX_PIP_VERSION: '20.2.4'
       run: tox
     - name: Upload coverage data
       uses: actions/upload-artifact@v2

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+Unreleased
+-------------------------
+* [Bug fix] Fix RDP connectivity check for IPv6 stacks.
+
 Version 4.1.14 (2021-04-21)
 --------------------------
 * [Bug fix] Refactor closing ssh connection in `finally` blocks.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 Unreleased
 -------------------------
+* [Bug fix] Truncate the error message for `LaunchError` to fit
+  256 characters and thus, could be added to the `error_msg` field
+  of a `Stack`.
 * [Bug fix] Fix RDP connectivity check for IPv6 stacks.
 
 Version 4.1.14 (2021-04-21)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 Unreleased
 -------------------------
+* [EOL] This is the final release in the 4.1 series. Everyone should
+  upgrade to at least version 5.
 * [Bug fix] Truncate the error message for `LaunchError` to fit
   256 characters and thus, could be added to the `error_msg` field
   of a `Stack`.

--- a/README.md
+++ b/README.md
@@ -14,11 +14,9 @@ browser-based connection mechanism, which includes the ability to connect to
 graphical user environments (via VNC and RDP), in addition to terminals (via
 SSH).
 
-> **Important notice for versions 4 and earlier**
+> **This release series has reached its end of life.**
 >
-> The latest Open edX release supported by hastexo XBlock versions 4
-> and earlier is [**Open edX
-> Juniper**](https://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/juniper.html). Open
+> Open
 > edX deployments using [Open edX
 > Koa](https://edx.readthedocs.io/projects/open-edx-release-notes/en/latest/koa.html)
 > and later should at least use hastexo XBlock version 5.

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -44,7 +44,7 @@ class LaunchError(Exception):
     def __init__(self, error_msg):
         super(LaunchError, self).__init__()
 
-        self.error_msg = error_msg
+        self.error_msg = textwrap.shorten(error_msg, width=256)
 
 
 @XBlock.wants('settings')

--- a/hastexo/tasks.py
+++ b/hastexo/tasks.py
@@ -516,11 +516,11 @@ class LaunchStackTask(HastexoTask):
             port = 3389
 
         connected = False
-        s = socket.socket()
-        s.settimeout(self.get_sleep_timeout())
+        conn = None
         while not connected:
             try:
-                s.connect((stack_ip, port))
+                conn = socket.create_connection((stack_ip, port),
+                                                self.get_sleep_timeout())
             except SoftTimeLimitExceeded:
                 raise
             except Exception:
@@ -528,7 +528,8 @@ class LaunchStackTask(HastexoTask):
             else:
                 connected = True
             finally:
-                s.close()
+                if conn:
+                    conn.close()
 
     def check_stack(self, stack_outputs, was_resumed, provider):
         """

--- a/requirements/flake8.txt
+++ b/requirements/flake8.txt
@@ -1,2 +1,1 @@
--r base.txt
 flake8

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,9 +12,6 @@ mako==1.0.2
 sqlparse==0.3.1
 web-fragments==0.3.2
 
-# XBlock SDK
--e git://github.com/edx/xblock-sdk.git@master#egg=xblock-sdk==master
-
 # Other XBlocks that are supported as nested elements
 markdown-xblock
 

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -155,7 +155,7 @@ class HastexoTestCase(TestCase):
         return self.mocks["ssh_to"]
 
     def get_socket_mock(self):
-        return self.mocks["socket"].socket.return_value
+        return self.mocks["socket"]
 
     def get_stack(self, prop=None):
         return get_stack(self.stack_name, self.course_id, self.student_id,
@@ -1307,7 +1307,7 @@ class TestLaunchStackTask(HastexoTestCase):
             self.stacks["CREATE_COMPLETE"]
         ]
         s = self.get_socket_mock()
-        s.connect.side_effect = [
+        s.create_connection.side_effect = [
             socket.timeout,
             socket.timeout,
             socket.timeout,
@@ -1324,7 +1324,8 @@ class TestLaunchStackTask(HastexoTestCase):
         stack = self.get_stack()
 
         # Assertions
-        s.connect.assert_called_with((self.STACK_IP, 3389))
+        s.create_connection.assert_called_with(
+            (self.STACK_IP, 3389), self.settings['sleep_timeout'])
         self.assertEqual(stack.status, "LAUNCH_TIMEOUT")
 
     def test_dont_wait_forever_for_rdp_on_custom_port(self):
@@ -1334,7 +1335,7 @@ class TestLaunchStackTask(HastexoTestCase):
             self.stacks["CREATE_COMPLETE"]
         ]
         s = self.get_socket_mock()
-        s.connect.side_effect = [
+        s.create_connection.side_effect = [
             socket.timeout,
             socket.timeout,
             socket.timeout,
@@ -1355,7 +1356,8 @@ class TestLaunchStackTask(HastexoTestCase):
         stack = self.get_stack()
 
         # Assertions
-        s.connect.assert_called_with((self.STACK_IP, self.port))
+        s.create_connection.assert_called_with(
+            (self.STACK_IP, self.port), self.settings['sleep_timeout'])
         self.assertEqual(stack.status, "LAUNCH_TIMEOUT")
 
     def test_dont_wait_forever_for_suspension(self):

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,8 @@ exclude_lines =
 deps =
     -rrequirements/setup.txt
     -rrequirements/test.txt
+    py35: xblock-sdk<0.3
+    py38: xblock-sdk
     xblock13: XBlock>=1.3,<1.4
     xblock14: XBlock>=1.4,<1.5
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ commands =
     python run_tests.py []
 
 [testenv:flake8]
+skip_install = True
 deps =
     -rrequirements/flake8.txt
 commands = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     py35: xblock-sdk<0.3
     py38: xblock-sdk
     xblock13: XBlock>=1.3,<1.4
-    xblock14: XBlock>=1.4,<1.5
+    xblock14: XBlock==1.4.0
 commands =
     python run_tests.py []
 


### PR DESCRIPTION
Now that Lilac has been released, it sound like a good time to retire stable-4.1 and support only Koa and Lilac going forward.

Thus, backport the last few important fixes from master, so we can cut a final release and put this branch to rest.