### PR TITLE
Truncate error messages for stack update

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+-------------------------
+* [Bug fix] Make sure that any error message that is added to the
+  `error_msg` filed of a stack, gets truncated before a stack update.
+
 Version 5.0.15 (2021-06-11)
 -------------------------
 * [Bug fix] Truncate the error message for `LaunchError` to fit

--- a/hastexo/tasks.py
+++ b/hastexo/tasks.py
@@ -4,6 +4,7 @@ import traceback
 import socket
 import logging
 import ipaddress
+import textwrap
 
 from django.db import connection, transaction
 from django.db.utils import OperationalError
@@ -196,7 +197,7 @@ class LaunchStackTask(HastexoTask):
 
             stack_data = {
                 'status': e.status,
-                'error_msg': e.error_msg,
+                'error_msg': textwrap.shorten(e.error_msg, width=256),
                 'ip': None,
                 'user': "",
                 'key': "",
@@ -640,7 +641,7 @@ class SuspendStackTask(HastexoTask):
         # The suspender doesn't check task results, so just save status in the
         # database.
         stack_data = {
-            'error_msg': error_msg,
+            'error_msg': textwrap.shorten(error_msg, width=256),
             'status': status,
         }
 
@@ -723,7 +724,7 @@ class DeleteStackTask(HastexoTask):
         stack_data = {
             'status': status,
             'provider': provider,
-            'error_msg': error_msg,
+            'error_msg': textwrap.shorten(error_msg, width=256),
         }
         self.update_stack(stack_data)
 


### PR DESCRIPTION
Make sure that any time we update the value of the `error_msg`
field of a `Stack`, we truncate the message we add before the
stack update.