### PR TITLE
Bump minimum Django version to 2.2.24

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 -r base.txt
 
 # These package versions must be kept in sync with edx-platform as much as possible.
-django>=2.2.21,<3.0
+django>=2.2.24,<3.0
 celery>=4.4.7,<5
 xblock-utils==2.1.1
 six==1.15.0


### PR DESCRIPTION
Address CVE-2021-33203 and CVE-2021-33571 and silence Dependabot warning.