### PR TITLE
Add constraints to Django version requirement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+-------------------------
+* [Enhancement] Add contraints to Django version requirement for
+  the `hastexo_guacamole_client`.
+
 Version 5.0.16 (2021-09-01)
 -------------------------
 * [Bug fix] Make sure that any error message that is added to the

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,6 +16,7 @@ python-novaclient>=7.1.2,<16
 tenacity>=6.2,<8
 
 # for hastexo_guacamole_client
+django<4
 channels>=2.4.0,<3
 asgiref>=3.2.0,<3.2.2  # depends on our channels version
 mysqlclient<2.0.3  # keep in sync with edx-platform


### PR DESCRIPTION
The Hastexo XBlock depends on the Django version defined for `edx-platform`
but the `hastexo_guacamole_client` does not.
Add constraints to make sure we don't install a version we have not tested yet.