### PR TITLE
Fix mismatched HTML tags

### DIFF
--- a/hastexo/static/html/main.html
+++ b/hastexo/static/html/main.html
@@ -3,7 +3,7 @@
   <div id="container">
     <div id="terminal"></div>
   </div>
-  <p class="buttons bar">
+  <div class="buttons bar">
     <select class="port"></select>
     <input type="button" value="Reset" class="reset"></input>
     <input type="button" value="Check progress" class="check"></input>


### PR DESCRIPTION
A `<p>` was matched with a `</div>`, so fix by changing the `<p>` to `<div>`.