### PR TITLE
Add basic validation for static HTML content, and fix static HTML so it passes validation

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+Unreleased
+-------------------------
+* [Bug fix] Fix unbalanced tags (`<p>` vs. `<div>`) in the static
+  `main.html` template.
+* [Testing] Add basic HTML validation for static templates.
+
 Version 5.0.17 (2022-01-04)
 -------------------------
 * [Enhancement] Add contraints to Django version requirement for

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ Unreleased
 
 Version 5.0.17 (2022-01-04)
 -------------------------
-* [Enhancement] Add contraints to Django version requirement for
+* [Enhancement] Add constraints to Django version requirement for
   the `hastexo_guacamole_client`.
 
 Version 5.0.16 (2021-09-01)

--- a/hastexo/static/html/main.html
+++ b/hastexo/static/html/main.html
@@ -3,7 +3,7 @@
   <div id="container">
     <div id="terminal"></div>
   </div>
-  <p class="buttons bar">
+  <div class="buttons bar">
     <select class="port"></select>
     <input type="button" value="Reset" class="reset"></input>
     <input type="button" value="Check progress" class="check"></input>

--- a/hastexo/static/html/main.html
+++ b/hastexo/static/html/main.html
@@ -5,8 +5,8 @@
   </div>
   <div class="buttons bar">
     <select class="port"></select>
-    <input type="button" value="Reset" class="reset"></input>
-    <input type="button" value="Check progress" class="check"></input>
+    <input type="button" value="Reset" class="reset" />
+    <input type="button" value="Check progress" class="check" />
   </div>
   <div class="dialog" id="launch_pending">
     <div class="inner">
@@ -21,8 +21,8 @@
       <p class="message"></p>
       <p class="error_msg"></p>
       <p class="buttons">
-        <input type="button" class="ok" value="Ok"></input>
-        <input type="button" class="retry" value="Retry"></input>
+        <input type="button" class="ok" value="Ok" />
+        <input type="button" class="retry" value="Retry" />
       </p>
     </div>
   </div>
@@ -39,7 +39,7 @@
       <h2 class="hints_title">Hints</h2>
       <ul class="hints"></ul>
       <p class="buttons">
-        <input type="button" class="ok" value="Ok"></input>
+        <input type="button" class="ok" value="Ok" />
       </p>
     </div>
   </div>
@@ -49,8 +49,8 @@
       <p class="message">There was a problem checking your progress:</p>
       <p class="error_msg"></p>
       <p class="buttons">
-        <input type="button" class="ok" value="Ok"></input>
-        <input type="button" class="retry" value="Retry"></input>
+        <input type="button" class="ok" value="Ok" />
+        <input type="button" class="retry" value="Retry" />
       </p>
     </div>
   </div>
@@ -60,7 +60,7 @@
       <p class="message">You've been inactive here for a while, so we paused your lab environment.</p>
       <p>Click <strong>Ok</strong> to resume it.</p>
       <p class="buttons">
-        <input type="button" class="ok" value="Ok"></input>
+        <input type="button" class="ok" value="Ok" />
       </p>
     </div>
   </div>
@@ -78,8 +78,8 @@
 	this point.<br/>
 	You cannot undo this action.</p>
       <p class="buttons">
-        <input type="button" class="reset" value="Reset"></input>
-        <input type="button" class="cancel" value="Cancel"></input>
+        <input type="button" class="reset" value="Reset" />
+        <input type="button" class="cancel" value="Cancel" />
       </p>
     </div>
   </div>

--- a/tests/unit/test_hastexo.py
+++ b/tests/unit/test_hastexo.py
@@ -1,6 +1,9 @@
 import time
 import json
 import textwrap
+import pkg_resources
+import os
+
 from hastexo.models import Stack
 from hastexo.hastexo import HastexoXBlock
 from hastexo.common import (
@@ -35,6 +38,24 @@ def make_request(data, method='POST'):
     request.body = json.dumps(data).encode('utf-8') if data is not None else ""
     request.method = method
     return request
+
+
+class TestHastexoXBlockHTML(TestCase):
+    """
+    Basic lint/validation checks for the static content bundled with
+    the XBlock.
+
+    """
+
+    def test_static(self):
+        static_files = ['main.html']
+        for static_file in static_files:
+            source = pkg_resources.resource_stream(
+                'hastexo',
+                os.path.join('static', 'html', static_file)
+            )
+            etree.parse(source,
+                        etree.HTMLParser(recover=False))
 
 
 class TestHastexoXBlockParsing(XmlTest, TestCase):


### PR DESCRIPTION
This is an extension of PR #194, which it builds upon.

PR #194 showed that we do not have test coverage for the HTML template in `static`, allowing non-well-formed HTML to slip through and be packaged with the XBlock. Thus, add a unit test case that simply loads the file and parses it with `lxml.etree.HTMLParser` (with `recover=False` so the parser throws an exception on running into an HTML error).

Implementing that unit test then turned up an additional issue on top of the one that #194 fixes, namely incorrectly used `<input>` tags. Fix those as well.