### PR TITLE
Add support for Tutor deployment

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 Unreleased
 -------------------------
+* [Enhancement] Add support for Tutor deployment, by dropping the
+  `wait_for_ping` logic.
 * [Enhancement] Add support for Apache Guacamole version `1.4.0`,
   make it the new default.
 * [Enhancement] Make the `guacamole-common-js` library version


### PR DESCRIPTION
When deploying the edx-platform with Tutor, the functionality
for the `wait_for_ping` method breaks as the plugin is then
running inside a Docker container and unable to ping the newly
spun up lab.

We really don't need to rely on this logic as we are more interested
in the abilty to create an ssh or rdp connection to the lab.
We can drop the logic for it altogether.