### PR TITLE
Update the guacd environment variables

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 Unreleased
 -------------------------
+* [BREAKING CHANGE] Update the `GUACD_*` environment variables to
+  better suit a Tutor deployment. Rename the variables to
+  `GUACD_SERVICE_HOST` and `GUACD_SERVICE_PORT` to directly read
+  values set for the guacd service with the `tutor k8s` deployment.
+  Update the default values to support the `tutor local`/
+  `tutor dev` deployment.
 * [BREAKING CHANGE] Update dependencies that should be in sync with
   `edx-platform` to support the `Maple` release.
   As of 6.0, this XBlock only supports Open edX versions Maple and

--- a/hastexo_guacamole_client/consumers.py
+++ b/hastexo_guacamole_client/consumers.py
@@ -20,8 +20,8 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
         """
         Initiate the GuacamoleClient and create a connection to it.
         """
-        guacd_hostname = os.getenv('GUACD_HOSTNAME', 'localhost')
-        guacd_port = os.getenv('GUACD_PORT', 4822)
+        guacd_hostname = os.getenv('GUACD_SERVICE_HOST', 'guacd')
+        guacd_port = int(os.getenv('GUACD_SERVICE_PORT', '4822'))
 
         settings = get_xblock_settings()
 


### PR DESCRIPTION
Update the `GUACD_*` environment variables to better suit a
Tutor deployment.
Rename the variables to `GUACD_SERVICE_HOST` and `GUACD_SERVICE_PORT`
to directly read values set for the guacd service with the `tutor k8s`
deployment.
Update the default values to support the `tutor local`/`tutor dev`
deployments.