### PR TITLE
Allow moving on to next provider if one is not configured

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 Unreleased
 -------------------------
+* [Bug fix] Don't fail to run if a listed provider is not
+  configured. Allow to move on to the next provider and log a
+  warning message for the provider initialisation failure.
 * [BREAKING CHANGE] Update the `GUACD_*` environment variables to
   better suit a Tutor deployment. Rename the variables to
   `GUACD_SERVICE_HOST` and `GUACD_SERVICE_PORT` to directly read

--- a/hastexo/tasks.py
+++ b/hastexo/tasks.py
@@ -160,24 +160,34 @@ class LaunchStackTask(HastexoTask):
         self.providers = []
         for provider in stack.providers:
             p = Provider.init(provider["name"])
-            p.set_logger(logger)
-            p.set_capacity(provider["capacity"])
+            if p:
+                p.set_logger(logger)
+                p.set_capacity(provider["capacity"])
 
-            template = read_from_contentstore(
-                stack.course_id,
-                provider["template"]
-            )
-            p.set_template(template)
-
-            environment_path = provider.get("environment")
-            if environment_path:
-                environment = read_from_contentstore(
+                template = read_from_contentstore(
                     stack.course_id,
-                    environment_path
+                    provider["template"]
                 )
-                p.set_environment(environment)
+                p.set_template(template)
 
-            self.providers.append(p)
+                environment_path = provider.get("environment")
+                if environment_path:
+                    environment = read_from_contentstore(
+                        stack.course_id,
+                        environment_path
+                    )
+                    p.set_environment(environment)
+
+                self.providers.append(p)
+            else:
+                logger.warning(
+                    f'Failed to initialize provider: {provider["name"]}, '
+                    'make sure the necessary settings are in place, or remove '
+                    'the provider from the list to silence this warning.')
+        if not self.providers:
+            logger.error("No providers were successfully initialized, "
+                         "make sure you have the necessary settings in place.")
+            raise ProviderException()
 
         try:
             # Launch the stack and wait for it to complete.

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -774,6 +774,46 @@ class TestLaunchStackTask(HastexoTestCase):
                 self.stack_run
             )
 
+    def test_only_one_provider_configured(self):
+        # Setup
+        provider = self.mock_providers[2]
+        provider.get_stack.side_effect = [
+            self.stacks["DELETE_COMPLETE"]
+        ]
+        provider.create_stack.side_effect = [
+            self.stacks["CREATE_COMPLETE"]
+        ]
+        self.mocks["Provider"].init.side_effect = [
+            None,
+            None,
+            provider,
+        ]
+
+        # Run
+        LaunchStackTask().run(**self.kwargs)
+
+        # Fetch stack
+        stack = self.get_stack()
+
+        # Assertions
+        # Assert that if at least one provider is configured
+        # LaunchStackTask can still succeed
+        self.assertEqual(stack.status, "CREATE_COMPLETE")
+
+    def test_no_providers_configured(self):
+        # Setup
+        self.mocks["Provider"].init.side_effect = [
+            None,
+            None,
+            None,
+        ]
+
+        # Run
+        # Assert that if no providers are configured
+        # LaunchStackTask will raise a ProviderException
+        with self.assertRaises(ProviderException):
+            LaunchStackTask().run(**self.kwargs)
+
     def test_reset_stack(self):
         # Setup
         provider = self.mock_providers[0]


### PR DESCRIPTION
Don't fail to run if one from the list of providers is not
configured. Allow moving on to the next and log a warning message
about failing to initialise a provider.
If none of the listed providers are configured however, log an
error message and raise an exception.