### PR TITLE
Allow moving on to next provider if one is not configured, add bumpversion testenv (5.0 backports)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 Unreleased
 -------------------------
+* [Bug fix] Don't fail to run if a listed provider is not
+  configured. Allow to move on to the next provider and log a
+  warning message for the provider initialisation failure.
 * [Bug fix] Fix unbalanced tags (`<p>` vs. `<div>`) in the static
   `main.html` template.
 * [Testing] Add basic HTML validation for static templates.

--- a/HACKING.md
+++ b/HACKING.md
@@ -39,8 +39,9 @@ How to cut a release
 --------------------
 
 This repository uses
-[bumpversion](https://pypi.org/project/bumpversion/) for managing new
-releases.
+[bump2version](https://pypi.org/project/bump2version/) (the maintained
+fork of [bumpversion](https://github.com/peritus/bumpversion)) for
+managing new releases.
 
 Before cutting a new release, open `Changelog.md` and add a new
 section like this:
@@ -55,11 +56,11 @@ Unreleased
 
 Commit these changes on `master` as you normally would.
 
-Then, use `bumpversion` to increase the version number:
+Then, use `tox -e bumpversion` to increase the version number:
 
--   `bumpversion patch`: creates a new point release (such as 3.6.1)
--   `bumpversion minor`: creates a new minor release, with the patch level set to 0 (such as 3.7.0)
--   `bumpversion major`: creates a new major release, with the minor and patch levels set to 0 (such as 4.0.0)
+-   `tox -e bumpversion patch`: creates a new point release (such as 3.6.1)
+-   `tox -e bumpversion minor`: creates a new minor release, with the patch level set to 0 (such as 3.7.0)
+-   `tox -e bumpversion major`: creates a new major release, with the minor and patch levels set to 0 (such as 4.0.0)
 
 This creates a new commit, and also a new tag, named `v<num>`, where
 `<num>` is the new version number.

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -786,6 +786,46 @@ class TestLaunchStackTask(HastexoTestCase):
                 self.stack_run
             )
 
+    def test_only_one_provider_configured(self):
+        # Setup
+        provider = self.mock_providers[2]
+        provider.get_stack.side_effect = [
+            self.stacks["DELETE_COMPLETE"]
+        ]
+        provider.create_stack.side_effect = [
+            self.stacks["CREATE_COMPLETE"]
+        ]
+        self.mocks["Provider"].init.side_effect = [
+            None,
+            None,
+            provider,
+        ]
+
+        # Run
+        LaunchStackTask().run(**self.kwargs)
+
+        # Fetch stack
+        stack = self.get_stack()
+
+        # Assertions
+        # Assert that if at least one provider is configured
+        # LaunchStackTask can still succeed
+        self.assertEqual(stack.status, "CREATE_COMPLETE")
+
+    def test_no_providers_configured(self):
+        # Setup
+        self.mocks["Provider"].init.side_effect = [
+            None,
+            None,
+            None,
+        ]
+
+        # Run
+        # Assert that if no providers are configured
+        # LaunchStackTask will raise a ProviderException
+        with self.assertRaises(ProviderException):
+            LaunchStackTask().run(**self.kwargs)
+
     def test_reset_stack(self):
         # Setup
         provider = self.mock_providers[0]

--- a/tox.ini
+++ b/tox.ini
@@ -37,3 +37,16 @@ skip_install = True
 deps =
     -rrequirements/flake8.txt
 commands = flake8
+
+[testenv:bumpversion]
+skip_install = True
+passenv =
+  # Git can only find its global configuration if it knows where the
+  # user's HOME is.
+  HOME
+  # We set sign_tags in .bumpversion.cfg, so pass in the GnuPG agent
+  # reference to avoid having to retype the passphrase for an
+  # already-cached private key.
+  GPG_AGENT_INFO
+deps = bump2version
+commands = bump2version {posargs}


### PR DESCRIPTION
Companion PR to #201 and #203: backports for the `stable-5.0` branch. 