### PR TITLE
Bump version: 5.0.17 → 6.0.0rc0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 5.0.17
+current_version = 6.0.0rc0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<rc>\d+))?
 serialize = 
 	{major}.{minor}.{patch}rc{rc}

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-Unreleased
+Version 6.0.0rc0 (2022-02-23)
 -------------------------
 * [Bug fix] Don't fail to run if a listed provider is not
   configured. Allow to move on to the next provider and log a


### PR DESCRIPTION
Prepare the first release candidate of the 6.0.0 series.