### PR TITLE
Small updates to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ py38:
   stage: build
   script:
     - pip install tox
-    - tox -e py38-xblock14,py38-xblock15,flake8
+    - tox -e py38-xblock14,py38-xblock15,py38-xblock16,flake8
   artifacts:
     paths:
       - .coverage*
@@ -16,7 +16,7 @@ py39:
   stage: build
   script:
     - pip install tox
-    - tox -e py39-xblock14,py39-xblock15,flake8
+    - tox -e py39-xblock14,py39-xblock15,py39-xblock16,flake8
   artifacts:
     paths:
       - .coverage*

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ Unreleased
   Add configuration options for setting a time limit for using labs
   (`lab_usage_limit`) in seconds and how to handle a breach of the
   set limit (`lab_usage_limit_breach_policy`).
+* [Testing] Include XBlock 1.6 in the test matrix.
 
 Version 6.0.1 (2022-03-14)
 -------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39}-xblock{14,15},flake8
+envlist = py{38,39}-xblock{14,15,16},flake8
 
 [gh-actions]
 python =
@@ -29,6 +29,7 @@ deps =
     xblock-sdk
     xblock14: XBlock>=1.4,<1.5
     xblock15: XBlock>=1.5,<1.6
+    xblock16: XBlock>=1.6,<1.7
 commands =
     python run_tests.py []
 


### PR DESCRIPTION
Just a couple of small updates I queued up a little while back:

* Make it a little more convenient to compile `coverage` data (via `tox -e coverage`).
* Add XBlock 1.6 to the test matrix.