### PR TITLE
Bump version: 6.0.1 → 6.1.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 6.0.1
+current_version = 6.1.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<rc>\d+))?
 serialize = 
 	{major}.{minor}.{patch}rc{rc}

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-Unreleased
+Version 6.1.0 (2022-04-21)
 -------------------------
 * [Enhancement] Be more specific when raising the exception for
   restricting lab access due to lab usage limit being reached.


### PR DESCRIPTION
The added feature of limiting lab time justifies the minor release bump.