### PR TITLE
Improve tox configuration to catch dependency issues

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -12,6 +12,9 @@ jobs:
         python-version:
           - 3.8
           - 3.9
+        pip-version:
+          - 20.0.2
+          - 22.0.4
 
     steps:
     - name: Check out code
@@ -22,8 +25,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install tox tox-gh-actions
-    - name: Test with tox
+        pip install tox tox-gh-actions tox-pip-version
+    - env:
+        TOX_PIP_VERSION: ${{ matrix.pip-version }}
+      name: Test with tox (pip ${{ matrix.pip-version }})
       run: tox
     - name: Upload coverage data
       uses: actions/upload-artifact@v2

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,9 @@ Unreleased
   version 20 and earlier, which would lead to
   `pkg_resources.ContextualVersionConflict` errors when deployed on
   Open edX Maple.
+* [Testing] Enhance the test matrix to include the pip versions used
+  in Open edX Maple (20.0.2) and Nutmeg (22.0.4), and use pipdeptree
+  to automatically flag dependency version inconsistencies.
 
 Version 6.1.1 (2022-04-25)
 -------------------------

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,13 @@
+Unreleased
+-------------------------
+
+* [Bug fix] Set upper bounds for the `install_requires` list in
+  `setup.py`, to match those set in `requirements.txt`. This fixes a
+  version incompatibility problem when the package is installed by pip
+  version 20 and earlier, which would lead to
+  `pkg_resources.ContextualVersionConflict` errors when deployed on
+  Open edX Maple.
+
 Version 6.1.1 (2022-04-25)
 -------------------------
 * [Enhancement] Add `hidden` option for spinning up a lab

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,6 @@ tenacity>=6.2,<8
 # for hastexo_guacamole_client
 django<4
 channels>=2.4.0,<3
-asgiref>=3.2.0,<3.2.2  # depends on our channels version
 mysqlclient<2.1.0  # keep in sync with edx-platform
 jsonfield>=3.1.0,<4   # keep in sync with edx-platform
 pyguacamole>=0.11

--- a/setup.py
+++ b/setup.py
@@ -56,13 +56,13 @@ setup(
         'hastexo',
     ],
     install_requires=[
-        'apscheduler',
-        'google-api-python-client',
-        'paramiko',
-        'python-heatclient',
-        'python-keystoneclient',
-        'python-novaclient',
-        'tenacity',
+        'apscheduler<3.8',
+        'google-api-python-client<1.8',
+        'paramiko<2.8',
+        'python-heatclient<2',
+        'python-keystoneclient<3.22',
+        'python-novaclient<16',
+        'tenacity<8',
     ],
     entry_points={
         'xblock.v1': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = flake8,py{38,39}-xblock{14,15,16}
+envlist = flake8,pipdeptree{,-requirements},py{38,39}-xblock{14,15,16}
 
 [gh-actions]
 python =
-    3.8: flake8,py38
-    3.9: flake8,py39
+    3.8: flake8,pipdeptree,pipdeptree-requirements,py38
+    3.9: flake8,pipdeptree,pipdeptree-requirements,py39
 
 [flake8]
 ignore = E124,W504
@@ -32,6 +32,17 @@ deps =
     xblock16: XBlock>=1.6,<1.7
 commands =
     python run_tests.py []
+
+[testenv:pipdeptree]
+deps =
+    pipdeptree
+commands = pipdeptree -w fail
+
+[testenv:pipdeptree-requirements]
+deps =
+    -rrequirements.txt
+    pipdeptree
+commands = pipdeptree -w fail
 
 [testenv:flake8]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py{38,39}-xblock{14,15,16},flake8
+envlist = flake8,py{38,39}-xblock{14,15,16}
 
 [gh-actions]
 python =
-    3.8: py38,flake8
-    3.9: py39,flake8
+    3.8: flake8,py38
+    3.9: flake8,py39
 
 [flake8]
 ignore = E124,W504


### PR DESCRIPTION
We currently don't have a good way to verify our full dependency tree on CI runs. This may lead to unexpected
`pkg_resources.ContextualVersionConflict` exceptions when deploying to Open edX.

Add a new testenv, `pipdeptree`, which runs `setup.py` and also installs the [pipdeptree](https://pypi.org/project/pipdeptree/) package, then runs it in `-w fail` mode, turning all dependency warnings into errors that need fixing.

Also, add `pipdeptree-requirements`, which does the same but rather than observing just the `install_requires` list in `setup.py`, also reads `requirements.txt` and installs those packages.

Then, fix the errors that this flags.