### PR TITLE
Add a check to the `add_user_foreign_key` migration

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,12 @@
+Unreleased
+-------------------------
+
+* [Bug fix] Add a check to the `add_user_foreign_key` migration
+  file to find stacks that are missing a link to a real user account.
+  If such stack(s) exist, do not attempt to apply the migration,
+  instead raise an exception and provide an error message with
+  guidance on how to proceed.
+
 Version 6.1.2 (2022-06-22)
 -------------------------
 


### PR DESCRIPTION
It may happen that there are some problematic stacks in the database
that would cause the migration to fail when the stacks cannot be
linked to a user account. These stacks are most likely a result of
testing with staff access, overriding some requirements that learner
stacks are subject to.

Add a check to the migration to find out if such stacks exist and
if they do, raise an exception with a message providing the list of
problematic stack names and guidance how to proceed.