### PR TITLE
Bring back `asgiref` constraint; lower `Django` constraint

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+Unreleased
+-------------------------
+
+* [Bug fix] Bring back `asgiref` constraint and lower
+  `Django` constraint. These need to be
+  in sync with the `channels` version requirements.
+
 Version 6.1.3 (2022-06-29)
 -------------------------
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,8 +16,9 @@ python-novaclient>=7.1.2,<16
 tenacity>=6.2,<8
 
 # for hastexo_guacamole_client
-django<4
+django<3.2
 channels>=2.4.0,<3
+asgiref~=3.2.0 # depends on our channels version
 mysqlclient<2.1.0  # keep in sync with edx-platform
 jsonfield>=3.1.0,<4   # keep in sync with edx-platform
 pyguacamole>=0.11


### PR DESCRIPTION
The `asgiref` dependency needs to be in sync with the requirements of
the `channels` version we are using. However, we also need make
sure that our `Django` and `asgiref` versions are compatible.