### PR TITLE
Bump version: 6.1.3 → 6.1.4

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 6.1.3
+current_version = 6.1.4
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<rc>\d+))?
 serialize = 
 	{major}.{minor}.{patch}rc{rc}

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-Unreleased
+Version 6.1.4 (2022-07-06)
 -------------------------
 
 * [Bug fix] Bring back `asgiref` constraint and lower


### PR DESCRIPTION
Cut a release including the changes from #225.