### PR TITLE
Apply additional fix to add_user_foreign_key migration

### DIFF
--- a/hastexo/migrations/0010_add_user_foreign_key.py
+++ b/hastexo/migrations/0010_add_user_foreign_key.py
@@ -40,4 +40,13 @@ class Migration(migrations.Migration):
                 to=settings.AUTH_USER_MODEL),
         ),
         migrations.RunPython(backfill_learner),
+        migrations.AlterField(
+            model_name='stack',
+            name='learner',
+            field=models.ForeignKey(
+                db_constraint=True,
+                null=True,
+                on_delete=django.db.models.deletion.PROTECT,
+                to=settings.AUTH_USER_MODEL),
+        ),
     ]


### PR DESCRIPTION
The hack in 583fb729b1e201c830579345dca5beca4b131006 modified
0010_add_user_foreign_key in such a way that it ended up *not* setting
a database constraint when it should have.

Enable the database-enforced constraint in the right place.