### PR TITLE
Add an option to override the global `suspend_timeout` setting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+Unreleased
+-------------------------
+
+* [Enhancement] Add an option to override the `suspend_timeout`
+  global setting via an XBlock attribute, in seconds.
+
 Version 6.1.5 (2022-07-13)
 -------------------------
 

--- a/README.md
+++ b/README.md
@@ -623,6 +623,10 @@ The following are optional:
 * `launch_timeout`: How long to wait for a stack to be launched, in seconds.
   If unset, the global timeout will be used.
 
+* `suspend_timeout`: Timeout for how long to wait before suspending a stack,
+  after the last keepalive was received from the browser, in seconds.
+  Takes precedence over the globally defined timeout."
+
 * `delete_age`: Delete stacks that haven't been resumed in this many seconds.
   Overrides the globally defined setting. The global setting currently only
   supports days but will begin to support suffixes `d`, `h`, `m`, `s` in future

--- a/hastexo/admin.py
+++ b/hastexo/admin.py
@@ -89,7 +89,7 @@ class StackAdmin(admin.ModelAdmin):
     search_fields = ("name", "course_id", "status", "provider")
     readonly_fields = ("name", student_email, "course_id", "run", "protocol",
                        "port", "ip", "launch_timestamp", "suspend_timestamp",
-                       "created_on", "error_msg", "delete_age",)
+                       "suspend_by", "created_on", "error_msg", "delete_age",)
     exclude = ("student_id", "providers", "hook_script", "hook_events",
                "launch_task_id", "user", "key", "password", "learner")
     ordering = ("-launch_timestamp",)

--- a/hastexo/migrations/0012_add_suspend_by.py
+++ b/hastexo/migrations/0012_add_suspend_by.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('hastexo', '0011_allow_null_for_learner'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='stack',
+            name='suspend_by',
+            field=models.DateTimeField(db_index=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='stacklog',
+            name='suspend_by',
+            field=models.DateTimeField(db_index=True, null=True),
+        ),
+    ]

--- a/hastexo/models.py
+++ b/hastexo/models.py
@@ -49,6 +49,7 @@ class StackCommon(models.Model):
     launch_task_id = models.CharField(max_length=40, blank=True)
     launch_timestamp = models.DateTimeField(null=True, db_index=True)
     suspend_timestamp = models.DateTimeField(null=True, db_index=True)
+    suspend_by = models.DateTimeField(null=True, db_index=True)
     created_on = models.DateTimeField(auto_now_add=True, db_index=True)
     delete_age = models.IntegerField(null=True)
     delete_by = models.DateTimeField(null=True, db_index=True,

--- a/tests/unit/test_hastexo.py
+++ b/tests/unit/test_hastexo.py
@@ -1004,6 +1004,14 @@ class TestHastexoXBlock(TestCase):
         stack_name = self.block.get_stack_name()
         self.assertEqual('course_run_student', stack_name)
 
+    def test_get_suspend_timeout(self):
+        self.init_block()
+        self.assertEqual(self.block.get_suspend_timeout(),
+                         DEFAULT_SETTINGS["suspend_timeout"])
+        self.block.suspend_timeout = 1800
+        self.assertEqual(self.block.get_suspend_timeout(),
+                         self.block.suspend_timeout)
+
     def test_get_stack_name_replace_characters(self):
         course_id = Mock(course='course.name', run='run')
         student_id = 'student'


### PR DESCRIPTION
Introduce a new XBlock attribute for overriding the `suspend_timeout`
setting.