### PR TITLE
Bump version: 6.1.5 → 6.2.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 6.1.5
+current_version = 6.2.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<rc>\d+))?
 serialize = 
 	{major}.{minor}.{patch}rc{rc}

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-Unreleased
+Version 6.2.0 (2022-07-21)
 -------------------------
 
 * [Enhancement] Add an option to override the `suspend_timeout`


### PR DESCRIPTION
PR #230 added a new feature, so per SemVer rules we should bump the minor.