### PR TITLE
Manually register Celery class-based tasks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 Unreleased
 -------------------------
-
+* [Bug fix] From Celery 5.0.0 the legacy task API was discontinued.
+  This meant that the Task base class no longer automatically registered 
+  child tasks in Open edX Nutmeg (which uses Celery 5.2.6). 
+  Manually register the class-based tasks on the Celery app instance.
+  
 * [BREAKING CHANGE] Update the `hastexo_guacamole_client` to
   Channels 3. The asgi root application (`ASGI_APPLICATION`)
   is now defined in the `asgi.py` file instead of `routing.py` file.

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -738,7 +738,7 @@ class HastexoXBlock(XBlock,
         soft_time_limit = self.get_launch_timeout(settings)
         hard_time_limit = soft_time_limit + 30
 
-        return LaunchStackTask().apply_async(
+        return LaunchStackTask.apply_async(
             kwargs=kwargs,
             expires=soft_time_limit,
             soft_time_limit=soft_time_limit,
@@ -746,7 +746,7 @@ class HastexoXBlock(XBlock,
         )
 
     def launch_stack_task_result(self, task_id):
-        return LaunchStackTask().AsyncResult(task_id)
+        return LaunchStackTask.AsyncResult(task_id)
 
     @XBlock.json_handler
     @transaction.atomic
@@ -924,9 +924,8 @@ class HastexoXBlock(XBlock,
         self.update_stack({"port": int(data.get("port"))})
 
     def check_progress_task(self, soft_time_limit, **kwargs):
-        task = CheckStudentProgressTask()
         time_limit = soft_time_limit + 30
-        result = task.apply_async(
+        result = CheckStudentProgressTask.apply_async(
             kwargs=kwargs,
             expires=soft_time_limit,
             soft_time_limit=soft_time_limit,
@@ -936,7 +935,7 @@ class HastexoXBlock(XBlock,
         return result
 
     def check_progress_task_result(self, check_id):
-        return CheckStudentProgressTask().AsyncResult(check_id)
+        return CheckStudentProgressTask.AsyncResult(check_id)
 
     @XBlock.json_handler
     def get_check_status(self, data, suffix=''):

--- a/hastexo/jobs.py
+++ b/hastexo/jobs.py
@@ -113,7 +113,7 @@ class SuspenderJob(AbstractJob):
         kwargs = {
             "stack_id": stack.id
         }
-        SuspendStackTask().apply_async(
+        SuspendStackTask.apply_async(
             kwargs=kwargs,
             soft_time_limit=soft_time_limit,
             time_limit=hard_time_limit,
@@ -203,7 +203,7 @@ class ReaperJob(AbstractJob):
         kwargs = {
             "stack_id": stack.id
         }
-        DeleteStackTask().apply_async(
+        DeleteStackTask.apply_async(
             kwargs=kwargs,
             soft_time_limit=soft_time_limit,
             time_limit=hard_time_limit,

--- a/hastexo/tasks.py
+++ b/hastexo/tasks.py
@@ -8,10 +8,7 @@ from django.db import connection, transaction
 from django.db.utils import OperationalError
 from django.utils import timezone
 
-try:
-    from celery.task import Task
-except ImportError:  # Celery <4
-    from celery import Task
+from celery import Task
 from celery.utils.log import get_task_logger
 from celery.exceptions import SoftTimeLimitExceeded
 from tenacity import (
@@ -46,6 +43,7 @@ from .common import (
     RemoteExecException,
     RemoteExecTimeout,
 )
+from celery import current_app
 
 logger = get_task_logger(__name__)
 
@@ -132,6 +130,8 @@ class LaunchStackTask(HastexoTask):
     user.
 
     """
+
+    name = "hastexo.tasks.launch_stack_task"
 
     def run(self, **kwargs):
         """
@@ -664,6 +664,9 @@ class SuspendStackTask(HastexoTask):
     Suspends a stack.
 
     """
+
+    name = "hastexo.tasks.suspend_stack_task"
+
     def run(self, **kwargs):
         for key, value in kwargs.items():
             setattr(self, key, value)
@@ -743,6 +746,9 @@ class DeleteStackTask(HastexoTask):
     Deletes a stack.
 
     """
+
+    name = "hastexo.tasks.delete_stack_task"
+
     def run(self, **kwargs):
         for key, value in kwargs.items():
             setattr(self, key, value)
@@ -861,6 +867,8 @@ class CheckStudentProgressTask(HastexoTask):
 
     """
 
+    name = "hastexo.tasks.check_student_progress_task"
+
     def run(self, **kwargs):
         """
         Run the celery task.
@@ -917,3 +925,10 @@ class CheckStudentProgressTask(HastexoTask):
             'total': len(self.tests),
             'errors': errors
         }
+
+
+LaunchStackTask = current_app.register_task(LaunchStackTask())
+SuspendStackTask = current_app.register_task(SuspendStackTask())
+DeleteStackTask = current_app.register_task(DeleteStackTask())
+CheckStudentProgressTask = current_app.register_task(
+    CheckStudentProgressTask())

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,6 @@
 -r base.txt
 
 # These package versions must be kept in sync with edx-platform as much as possible.
-celery>=4.4.7,<5
 xblock-utils==2.2.0
 six==1.16.0
 lazy==1.4

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -68,10 +68,10 @@ class TestHastexoJobs(TestCase):
             self.addCleanup(patcher.stop)
 
     def get_suspend_task_mock(self):
-        return self.mocks["SuspendStackTask"].return_value
+        return self.mocks["SuspendStackTask"]
 
     def get_delete_task_mock(self):
-        return self.mocks["DeleteStackTask"].return_value
+        return self.mocks["DeleteStackTask"]
 
     def test_dont_suspend_stack_with_no_provider(self):
         # Setup

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -198,7 +198,7 @@ class TestLaunchStackTask(HastexoTestCase):
         ]
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -226,7 +226,7 @@ class TestLaunchStackTask(HastexoTestCase):
             ]
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -260,7 +260,7 @@ class TestLaunchStackTask(HastexoTestCase):
                                         OperationalError,
                                         Stack.objects]
             # Run
-            LaunchStackTask().run(**self.kwargs)
+            LaunchStackTask.run(**self.kwargs)
 
         # The filter() method would have to be called 3 times
         # (2 failures with an OperationalError, then 1 success).
@@ -307,7 +307,7 @@ class TestLaunchStackTask(HastexoTestCase):
                                         OperationalError]
             # Run
             with self.assertRaises(OperationalError):
-                LaunchStackTask().run(**self.kwargs)
+                LaunchStackTask.run(**self.kwargs)
 
             # The filter() method would have to be called 3 times.
             self.assertEqual(filter_patch.call_count, 3)
@@ -332,7 +332,7 @@ class TestLaunchStackTask(HastexoTestCase):
         ]
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -357,7 +357,7 @@ class TestLaunchStackTask(HastexoTestCase):
         ]
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -375,7 +375,7 @@ class TestLaunchStackTask(HastexoTestCase):
             ]
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -402,7 +402,7 @@ class TestLaunchStackTask(HastexoTestCase):
         ]
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -424,7 +424,7 @@ class TestLaunchStackTask(HastexoTestCase):
         self.kwargs["reset"] = True
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -448,7 +448,7 @@ class TestLaunchStackTask(HastexoTestCase):
         })
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -479,7 +479,7 @@ class TestLaunchStackTask(HastexoTestCase):
         ]
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -504,7 +504,7 @@ class TestLaunchStackTask(HastexoTestCase):
         ]
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -532,7 +532,7 @@ class TestLaunchStackTask(HastexoTestCase):
         })
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -547,10 +547,10 @@ class TestLaunchStackTask(HastexoTestCase):
         self.providers[0].pop("capacity")
         self.update_stack({"providers": self.providers})
 
-        # Assert LaunchStackTask() fails if capacity is not defined
+        # Assert LaunchStackTask fails if capacity is not defined
         # for a provider.
         with self.assertRaises(KeyError):
-            LaunchStackTask().run(**self.kwargs)
+            LaunchStackTask.run(**self.kwargs)
 
     def test_infinite_capacity(self):
         # Setup
@@ -574,7 +574,7 @@ class TestLaunchStackTask(HastexoTestCase):
             self.create_stack(name, self.course_id, student_id, data)
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -603,7 +603,7 @@ class TestLaunchStackTask(HastexoTestCase):
         ]
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -641,7 +641,7 @@ class TestLaunchStackTask(HastexoTestCase):
             self.create_stack(name, self.course_id, student_id, data)
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -674,7 +674,7 @@ class TestLaunchStackTask(HastexoTestCase):
         self.update_stack({"providers": self.providers})
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -703,7 +703,7 @@ class TestLaunchStackTask(HastexoTestCase):
         ]
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -732,7 +732,7 @@ class TestLaunchStackTask(HastexoTestCase):
         ]
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -749,7 +749,7 @@ class TestLaunchStackTask(HastexoTestCase):
         ]
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -769,7 +769,7 @@ class TestLaunchStackTask(HastexoTestCase):
             ]
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -800,7 +800,7 @@ class TestLaunchStackTask(HastexoTestCase):
         ]
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -822,7 +822,7 @@ class TestLaunchStackTask(HastexoTestCase):
         # Assert that if no providers are configured
         # LaunchStackTask will raise a ProviderException
         with self.assertRaises(ProviderException):
-            LaunchStackTask().run(**self.kwargs)
+            LaunchStackTask.run(**self.kwargs)
 
     def test_reset_stack(self):
         # Setup
@@ -844,7 +844,7 @@ class TestLaunchStackTask(HastexoTestCase):
         self.kwargs["reset"] = True
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -868,7 +868,7 @@ class TestLaunchStackTask(HastexoTestCase):
         self.kwargs["reset"] = True
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -894,7 +894,7 @@ class TestLaunchStackTask(HastexoTestCase):
         self.kwargs["reset"] = True
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -918,7 +918,7 @@ class TestLaunchStackTask(HastexoTestCase):
         })
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -958,7 +958,7 @@ class TestLaunchStackTask(HastexoTestCase):
                                                       OperationalError,
                                                       None]) as save_patch:
             # Run
-            LaunchStackTask().run(**self.kwargs)
+            LaunchStackTask.run(**self.kwargs)
 
             # The save() method would have to be called 3 times (2
             # failures with an OperationalError, then 1 success).
@@ -998,7 +998,7 @@ class TestLaunchStackTask(HastexoTestCase):
                                         OperationalError]) as save_patch:
             # Run
             with self.assertRaises(OperationalError):
-                LaunchStackTask().run(**self.kwargs)
+                LaunchStackTask.run(**self.kwargs)
 
             # The save() method would have to be called 3 times.
             self.assertEqual(save_patch.call_count, 3)
@@ -1033,7 +1033,7 @@ class TestLaunchStackTask(HastexoTestCase):
         })
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1058,7 +1058,7 @@ class TestLaunchStackTask(HastexoTestCase):
         })
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1083,7 +1083,7 @@ class TestLaunchStackTask(HastexoTestCase):
         })
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1109,7 +1109,7 @@ class TestLaunchStackTask(HastexoTestCase):
         self.mocks["remote_exec"].side_effect = Exception()
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1135,7 +1135,7 @@ class TestLaunchStackTask(HastexoTestCase):
         self.mocks["remote_exec"].side_effect = RemoteExecException
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1158,7 +1158,7 @@ class TestLaunchStackTask(HastexoTestCase):
         })
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1180,7 +1180,7 @@ class TestLaunchStackTask(HastexoTestCase):
         })
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1206,7 +1206,7 @@ class TestLaunchStackTask(HastexoTestCase):
         })
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1231,7 +1231,7 @@ class TestLaunchStackTask(HastexoTestCase):
         self.update_stack({"providers": self.providers})
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1255,7 +1255,7 @@ class TestLaunchStackTask(HastexoTestCase):
         self.update_stack({"providers": self.providers})
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1276,7 +1276,7 @@ class TestLaunchStackTask(HastexoTestCase):
         self.update_stack({"provider": self.providers[0]["name"]})
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1299,7 +1299,7 @@ class TestLaunchStackTask(HastexoTestCase):
         self.update_stack({"provider": self.providers[0]["name"]})
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1317,7 +1317,7 @@ class TestLaunchStackTask(HastexoTestCase):
         self.update_stack({"provider": self.providers[0]["name"]})
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1335,7 +1335,7 @@ class TestLaunchStackTask(HastexoTestCase):
         self.update_stack({"provider": self.providers[0]["name"]})
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1362,7 +1362,7 @@ class TestLaunchStackTask(HastexoTestCase):
         self.update_stack({"protocol": self.protocol})
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1394,7 +1394,7 @@ class TestLaunchStackTask(HastexoTestCase):
         })
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1418,7 +1418,7 @@ class TestLaunchStackTask(HastexoTestCase):
         })
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1438,7 +1438,7 @@ class TestLaunchStackTask(HastexoTestCase):
         ]
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1464,7 +1464,7 @@ class TestLaunchStackTask(HastexoTestCase):
         })
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1492,7 +1492,7 @@ class TestLaunchStackTask(HastexoTestCase):
         })
 
         # Run
-        LaunchStackTask().run(**self.kwargs)
+        LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1522,10 +1522,10 @@ class TestLaunchStackTask(HastexoTestCase):
         })
 
         # Run
-        # Assert LaunchStackTask() raises an exception when time
+        # Assert LaunchStackTask raises an exception when time
         # limit is breached and the breach policy is set to 'block'
         with self.assertRaises(Exception):
-            LaunchStackTask().run(**self.kwargs)
+            LaunchStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1551,7 +1551,7 @@ class TestSuspendStackTask(HastexoTestCase):
         ]
 
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1582,7 +1582,7 @@ class TestSuspendStackTask(HastexoTestCase):
         ]
 
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1614,7 +1614,7 @@ class TestSuspendStackTask(HastexoTestCase):
         ]
 
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1644,7 +1644,7 @@ class TestSuspendStackTask(HastexoTestCase):
         ]
 
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1676,7 +1676,7 @@ class TestSuspendStackTask(HastexoTestCase):
         ]
 
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1704,7 +1704,7 @@ class TestSuspendStackTask(HastexoTestCase):
         ]
 
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1727,7 +1727,7 @@ class TestSuspendStackTask(HastexoTestCase):
         ]
 
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1748,7 +1748,7 @@ class TestSuspendStackTask(HastexoTestCase):
         provider.get_stack.side_effect = Exception()
 
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1771,7 +1771,7 @@ class TestSuspendStackTask(HastexoTestCase):
         provider.suspend_stack.side_effect = SoftTimeLimitExceeded
 
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1793,7 +1793,7 @@ class TestSuspendStackTask(HastexoTestCase):
         ]
 
         # Run
-        SuspendStackTask().run(**self.kwargs)
+        SuspendStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1824,7 +1824,7 @@ class TestDeleteStackTask(HastexoTestCase):
         ]
 
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1853,7 +1853,7 @@ class TestDeleteStackTask(HastexoTestCase):
         ]
 
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1879,7 +1879,7 @@ class TestDeleteStackTask(HastexoTestCase):
         ]
 
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1911,7 +1911,7 @@ class TestDeleteStackTask(HastexoTestCase):
         ]
 
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1940,7 +1940,7 @@ class TestDeleteStackTask(HastexoTestCase):
         ]
 
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -1969,7 +1969,7 @@ class TestDeleteStackTask(HastexoTestCase):
         ]
 
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -2003,7 +2003,7 @@ class TestDeleteStackTask(HastexoTestCase):
         ]
 
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -2035,7 +2035,7 @@ class TestDeleteStackTask(HastexoTestCase):
         ]
 
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -2069,7 +2069,7 @@ class TestDeleteStackTask(HastexoTestCase):
         ]
 
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -2100,7 +2100,7 @@ class TestDeleteStackTask(HastexoTestCase):
         ]
 
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -2126,7 +2126,7 @@ class TestDeleteStackTask(HastexoTestCase):
         provider.delete_stack.side_effect = SoftTimeLimitExceeded
 
         # Run
-        DeleteStackTask().run(**self.kwargs)
+        DeleteStackTask.run(**self.kwargs)
 
         # Fetch stack
         stack = self.get_stack()
@@ -2163,7 +2163,7 @@ class TestCheckStudentProgressTask(HastexoTestCase):
         }
 
         # Run
-        res = CheckStudentProgressTask().run(**kwargs)
+        res = CheckStudentProgressTask.run(**kwargs)
 
         # Assertions
         self.assertEqual(res["status"], "CHECK_PROGRESS_COMPLETE")
@@ -2187,7 +2187,7 @@ class TestCheckStudentProgressTask(HastexoTestCase):
         }
 
         # Run
-        res = CheckStudentProgressTask().run(**kwargs)
+        res = CheckStudentProgressTask.run(**kwargs)
 
         # Assertions
         self.assertEqual(res["status"], "CHECK_PROGRESS_COMPLETE")
@@ -2232,7 +2232,7 @@ class TestCheckStudentProgressTask(HastexoTestCase):
         }
 
         # Run
-        res = CheckStudentProgressTask().run(**kwargs)
+        res = CheckStudentProgressTask.run(**kwargs)
 
         # Assertions
         self.assertEqual(res["status"], "CHECK_PROGRESS_COMPLETE")

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,pipdeptree{,-requirements},py{38,39}-xblock{14,15,16}
+envlist = flake8,pipdeptree{,-requirements},py{38,39}-xblock{14,15,16}-celery{4,5}
 
 [gh-actions]
 python =
@@ -30,6 +30,8 @@ deps =
     xblock14: XBlock>=1.4,<1.5
     xblock15: XBlock>=1.5,<1.6
     xblock16: XBlock>=1.6,<1.7
+    celery4: celery>=4,<5
+    celery5: celery>=5,<6
 commands =
     python run_tests.py []
 


### PR DESCRIPTION
From Celery 5.0.0 the [legacy task API was discontinued](https://github.com/celery/celery/pull/6315), which means that the Task base class no longer automatically registers child tasks.
Therefore to use hastexo-xblock with Open edX Nutmeg (which uses Celery 5.2.6), we need to [manually register the class-based tasks](https://docs.celeryq.dev/en/master/history/whatsnew-4.0.html#the-task-base-class-no-longer-automatically-register-tasks) on the Celery app instance.