### PR TITLE
Remove references to old Devstack from README

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,7 +11,7 @@ Unreleased
   meaning if you want to allow the LMS to connect to labs via the `hastexo_guacamole_client`, the LMS host has to be listed in
   `ALLOWED_HOSTS` at `hastexo_guacamole_client.settings.py`.
 * [Documentation] Remove obsolete deployment instructions for the
-  old “native” (Ansible-based) installation.
+  old “native” (Ansible-based) installation, and the old Devstack.
 
 Version 6.2.0 (2022-07-21)
 -------------------------

--- a/README.md
+++ b/README.md
@@ -712,33 +712,6 @@ actual stack states in case of failure.  It should not be necessary to do so in
 day-to-day usage of the XBlock.
 
 
-## Usage in devstack
-
-It is possible to use this XBlock in devstack.  To do so, however, requires
-tweaking a few settings.
-
-First, devstacks don't install nginx.  Therefore, the Guacamole app is only
-reachable directly at its configured port.  This means that `terminal_url` in
-the XBlock settings must be set to that port (by default, 8080):
-
-    ```
-    "XBLOCK_SETTINGS": {
-        "hastexo": {
-            "terminal_url": ":8080/hastexo-xblock/"
-        }
-    }
-    ```
-
-Next, open three terminal windows, and run each of the following concurrently:
-
-    ```
-    paver devstack lms --settings=devstack_with_worker
-    ./manage.py lms celery worker --settings=devstack_with_worker -l DEBUG
-    ./manage.py lms --settings=devstack_with_worker suspender
-    ./manage.py lms --settings=devstack_with_worker reaper
-    ```
-
-
 ## Running tests
 
 The testing framework is built on


### PR DESCRIPTION
The old Devstack is no longer recommended/supported, developers should just use `tutor dev` instead.

Reference:
https://docs.tutor.overhang.io/dev.html