### PR TITLE
Prepare 7.0.0 release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 6.2.0
+current_version = 7.0.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<rc>\d+))?
 serialize = 
 	{major}.{minor}.{patch}rc{rc}

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-Unreleased
+Version 7.0.0 (2022-08-22)
 -------------------------
 * [Bug fix] From Celery 5.0.0 the legacy task API was discontinued.
   This meant that the Task base class no longer automatically registered 

--- a/README.md
+++ b/README.md
@@ -15,16 +15,17 @@ graphical user environments (via VNC and RDP), in addition to terminals (via
 SSH).
 
 
-> **Important changes in version 6**
+> **Important changes in version 7**
 >
-> As of version 6, this XBlock only supports the Open edX versions `Maple`
-> and higher. Starting with the Maple release, the Open edX community has
-> switched the supported deployment method from edx-configuration playbooks
-> to [Tutor](https://docs.tutor.overhang.io) and the same applies
-> for this XBlock.
+> Version 7 of this XBlock is intended to be deployed on Open edX
+> Nutmeg, with [Tutor](https://docs.tutor.overhang.io/) version 14.x
+> and [the `hastexo` Tutor
+> plugin](https://github.com/hastexo/tutor-contrib-hastexo), version
+> 1.x.
 >
-> Instructions for deploying this XBlock with Tutor can be found below,
-> in the Deployment section.
+> Instructions for deploying this XBlock with Tutor can be found
+> below, in the [Deployment with Tutor](#deployment-with-tutor)
+> section.
 
 ## Purpose
 


### PR DESCRIPTION
* Update the "Important changes" section in the README from version 6 to version 7.
* Bump the major number.