### PR TITLE
Fix residual reference to version 6 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ two steps:
    `OPENEDX_EXTRA_PIP_REQUIREMENTS` list in `config.yml`:
    ```
    OPENEDX_EXTRA_PIP_REQUIREMENTS:
-     - "hastexo-xblock>=6"
+     - "hastexo-xblock>=7"
    ```
    For additional information, please refer to the [official
    documentation](https://docs.tutor.overhang.io/configuration.html#installing-extra-xblocks-and-requirements).


### PR DESCRIPTION
The suggested value for `OPENEDX_EXTRA_PIP_REQUIREMENTS` in the `README` still contained a reference to version 6. Fix it to refer to version 7 instead.