### PR TITLE
Drop Mako pin from test requirements

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,7 +5,6 @@ xblock-utils==2.2.0
 six==1.16.0
 lazy==1.4
 django-pyfs==3.1.0
-mako==1.1.5
 sqlparse>=0.4.1,<0.5
 web-fragments==1.1.0
 


### PR DESCRIPTION
The XBlock itself doesn't use Mako at all. There really is no reason to keep referencing any Mako version explicitly from the test requirements. So, drop it altogether.