### PR TITLE
Retry `read_from_contentstore()`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+* [Bug fix] Retry `read_from_contentstore()`. Use `tenacity`'s
+  retry functionality for getting course information from contentstore.
+
 Version 7.0.0 (2022-08-22)
 -------------------------
 * [Bug fix] From Celery 5.0.0 the legacy task API was discontinued.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,6 +10,7 @@ os-client-config>=1.28.0,<2
 oslo.serialization>=2.28.1,<3
 oslo.utils>=3.37.1,<4
 paramiko>=2.10.1,<2.11
+pymongo<4
 python-heatclient>=1.6.1,<2
 python-keystoneclient>=3.17.0,<3.22
 python-novaclient>=7.1.2,<16


### PR DESCRIPTION
There might occasionally be moments where we cannot reach MongoDB on first try.
Implement `tenacity`'s retry functionality for the purpose of trying again when that happens.