### PR TITLE
Fix unit and integration tests (and GitHub Actions workflows)

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -25,7 +25,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install tox tox-gh-actions tox-pip-version
+        pip install "tox<4" tox-gh-actions tox-pip-version
     - env:
         TOX_PIP_VERSION: ${{ matrix.pip-version }}
       name: Test with tox (pip ${{ matrix.pip-version }})

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -18,9 +18,9 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -31,7 +31,7 @@ jobs:
       name: Test with tox (pip ${{ matrix.pip-version }})
       run: tox
     - name: Upload coverage data
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: coverage-${{ matrix.python-version }}
         path: .coverage*
@@ -45,9 +45,9 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v1
     - name: Download artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install dependencies
@@ -61,10 +61,10 @@ jobs:
         coverage xml
         coverage report
     - name: Upload htmlcov archive
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: htmlcov
         path: htmlcov
         retention-days: 7
     - name: Upload to codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -17,5 +17,4 @@ path.py>=12.4
 # Tooling
 ddt
 nose
-mock
 coverage

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 try:
     from unittest.mock import patch
 except ImportError:
-    from mock import patch
+    from unittest.mock import patch
 
 
 class SuspenderTestCase(TestCase):

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -2,7 +2,7 @@ import ddt
 import errno
 
 from django.test import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 from pymongo.errors import (
     PyMongoError,
     ConnectionFailure,

--- a/tests/unit/test_gcloud.py
+++ b/tests/unit/test_gcloud.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch
+from unittest.mock import patch
 from hastexo.gcloud import GcloudDeploymentManager, GcloudComputeEngine
 
 

--- a/tests/unit/test_hastexo.py
+++ b/tests/unit/test_hastexo.py
@@ -17,7 +17,7 @@ from common.djangoapps.student.models import AnonymousUserId
 from fs.osfs import OSFS
 from lxml import etree
 from markdown_xblock import MarkdownXBlock
-from mock import Mock, patch, DEFAULT
+from unittest.mock import Mock, patch, DEFAULT
 from webob import Request
 from django.contrib.auth.models import User
 from django.test import TestCase

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.utils import timezone

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 from hastexo.openstack import OpenStackWrapper, HeatWrapper, NovaWrapper
 
 

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -3,7 +3,7 @@ import yaml
 import base64
 
 from unittest import TestCase
-from mock import Mock, patch, call
+from unittest.mock import Mock, patch, call
 from heatclient import exc as heat_exc
 from keystoneauth1.exceptions import http as keystone_exc
 from novaclient import exceptions as nova_exc

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -2,7 +2,7 @@ import copy
 import socket
 
 from unittest import TestCase
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from hastexo.models import Stack
 from hastexo.provider import ProviderException


### PR DESCRIPTION
tox 4.0.0, released in December 2022, removed the `tox.venv` module which `tox-pip-version` relies on.

Therefore, until
    
* tox-pip-version starts supporting tox 4, or
* we decide that we no longer need to test with multiple pip versions, and thus no longer have a need for installing tox-pip-version,
    
force a `tox` version earlier than 4.

Also, update the GitHub actions to their latest major releases, and drop the pip-installed `mock` module for the standard library's `unittest.mock` (like we should have done years ago, really).