### PR TITLE
Updates to the test matrix, in order to stay current with recent upstream versions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -15,8 +15,8 @@ jobs:
           - '3.10'
           - '3.11'
         pip-version:
-          - 20.0.2
           - 22.0.4
+          - 23.0.1
 
     steps:
     - name: Check out code

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,8 +10,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.8
-          - 3.9
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
         pip-version:
           - 20.0.2
           - 22.0.4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ py38:
   stage: build
   script:
     - pip install tox
-    - tox -e py38-xblock14,py38-xblock15,py38-xblock16,flake8
+    - tox -e flake8,pipdeptree,pipdeptree-requirements,py38-xblock15,py38-xblock16,py38-xblock17
   artifacts:
     paths:
       - .coverage*
@@ -16,12 +16,33 @@ py39:
   stage: build
   script:
     - pip install tox
-    - tox -e py39-xblock14,py39-xblock15,py39-xblock16,flake8
+    - tox -e flake8,pipdeptree,pipdeptree-requirements,py39-xblock15,py39-xblock16,py39-xblock17
   artifacts:
     paths:
       - .coverage*
     expire_in: 5 minutes
 
+py310:
+  image: python:3.10
+  stage: build
+  script:
+    - pip install tox
+    - tox -e flake8,pipdeptree,pipdeptree-requirements,py310-xblock15,py310-xblock16,py310-xblock17
+  artifacts:
+    paths:
+      - .coverage*
+    expire_in: 5 minutes
+
+py311:
+  image: python:3.11
+  stage: build
+  script:
+    - pip install tox
+    - tox -e flake8,pipdeptree,pipdeptree-requirements,py311-xblock15,py311-xblock16,py311-xblock17
+  artifacts:
+    paths:
+      - .coverage*
+    expire_in: 5 minutes
 
 coverage:
   stage: test

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
-envlist = flake8,pipdeptree{,-requirements},py{38,39}-xblock{15,16,17}-celery5
+envlist = flake8,pipdeptree{,-requirements},py{38,39,310,311}-xblock{15,16,17}-celery5
 
 [gh-actions]
 python =
     3.8: flake8,pipdeptree,pipdeptree-requirements,py38
     3.9: flake8,pipdeptree,pipdeptree-requirements,py39
+    3.10: flake8,pipdeptree,pipdeptree-requirements,py310
+    3.11: flake8,pipdeptree,pipdeptree-requirements,py311
 
 [flake8]
 ignore = E124,W504

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,pipdeptree{,-requirements},py{38,39}-xblock{14,15,16}-celery5
+envlist = flake8,pipdeptree{,-requirements},py{38,39}-xblock{15,16,17}-celery5
 
 [gh-actions]
 python =
@@ -27,9 +27,9 @@ deps =
     -rrequirements/setup.txt
     -rrequirements/test.txt
     xblock-sdk
-    xblock14: XBlock>=1.4,<1.5
     xblock15: XBlock>=1.5,<1.6
     xblock16: XBlock>=1.6,<1.7
+    xblock17: XBlock>=1.7,<1.8
     celery5: celery>=5,<6
 commands =
     python run_tests.py []

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,pipdeptree{,-requirements},py{38,39}-xblock{14,15,16}-celery{4,5}
+envlist = flake8,pipdeptree{,-requirements},py{38,39}-xblock{14,15,16}-celery5
 
 [gh-actions]
 python =
@@ -30,7 +30,6 @@ deps =
     xblock14: XBlock>=1.4,<1.5
     xblock15: XBlock>=1.5,<1.6
     xblock16: XBlock>=1.6,<1.7
-    celery4: celery>=4,<5
     celery5: celery>=5,<6
 commands =
     python run_tests.py []


### PR DESCRIPTION
Modify the test matrix in the following manner:

| Change  | Effect on build run time |
| ------------- | ------------- |
| Remove Celery 4  | Reduces run time from 14 minutes to 9  |
| Remove XBlock 1.4 and add XBlock 1.7 | No significant impact |
| Add Python 3.10 and 3.11  | No significant impact (multiple Python environments run in parallel)  |
| Replace pip 20.0.2 and add pip 23.0.1 | No significant impact |