### PR TITLE
fix: Restrict twisted to a version below 23.8.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+-------------------------
+* [Bug fix] Restrict Twisted dependency to `twisted<23.8.0` to remain
+  installable on Python 3.8 and 3.9.
+
 Version 7.7.0 (2023-08-24)
 -------------------------
 * [Enhancement] Add support for Ed25519 SSH keys by introducing

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,6 +19,7 @@ tenacity>=6.2,<8
 # for hastexo_guacamole_client
 django~=3.2.1
 channels>=3.0.0,<=3.0.5
+twisted<23.8.0 # drop this restriction once we drop Python 3.8 and 3.9 support
 asgiref<=3.5.2 # depends on our channels version
 mysqlclient<=2.1.1  # keep in sync with edx-platform
 jsonfield>=3.1.0,<4   # keep in sync with edx-platform


### PR DESCRIPTION
The `channels` package depends on `daphne`, which in turn depends on `twisted>=18.7`. Officially, `twisted`'s 23.8.0 release is the last to support even Python 3.7, so it ought to be fine to use, but `tox -e pipdeptree-requirements` fails on Python 3.8 and 3.9 while it succeeds on Python 3.10 and 3.11.

So, evidently the `twisted` 23.8.0 release (which landed on 2023-08-28) includes some transitive dependency on a package that has dropped support for Python 3.8 and 3.9.

Thus, restrict `twisted` to releases prior to 23.8.0. We can drop this restriction once we decide to drop Python 3.8 and 3.9 support.

Reference:
https://github.com/twisted/twisted/releases/tag/twisted-23.8.0