### PR TITLE
fix: Drop extraneous double quotes from reset warning

### DIFF
--- a/hastexo/static/html/main.html
+++ b/hastexo/static/html/main.html
@@ -72,7 +72,7 @@
       <p class="message">
         {% trans "Resetting will return your lab environment to a pristine state." %}
         <br/>
-        {% trans "This may take several minutes to complete." %}"
+        {% trans "This may take several minutes to complete." %}
         <span class="exam-warning">
         {% trans "In a timed exam, the timer will continue to run while your environment is being reset." %}</span>
         <br/>


### PR DESCRIPTION
In the pop-up dialog asking for confirmation after the learner has hit the Reset button, the warning `This may take several minutes to complete.` is followed by an extra `"` character.

Remove the extraneous character from the template.