### PR TITLE
fix: Fix editing the stack_key_type in Studio

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 Unreleased
 -------------------------
+* [Bug fix] Fix editing the `stack_key_type` field in Studio; include
+  the attribute in Studio export.
 * [Bug fix] Add better handling for SSH key cleanup when deleting stacks.
 
 Version 7.7.1 (2023-09-13)

--- a/README.md
+++ b/README.md
@@ -488,9 +488,9 @@ The following are optional:
   if not specified per provider below.
 
 * `stack_key_type`: An SSH key type for accessing the lab environment.
-  Options are `rsa`, `ed25519` and `None` (default). If a key type is chosen,
+  Options are `rsa`, `ed25519` and `""` (default). If a key type is chosen,
   a key with the selected type will be generated for the lab environment.
-  If set to `None`, the key handling should be done via the lab template.
+  If set to an empty string, the key handling should be done via the lab template.
 
 * `launch_timeout`: How long to wait for a stack to be launched, in seconds.
   If unset, the global timeout will be used.

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -106,8 +106,8 @@ class HastexoXBlock(XBlock,
              "the last keepalive was received from the browser, in seconds. "
              "Takes precedence over the globally defined timeout.")
     stack_key_type = String(
-        values=["rsa", "ed25519", None],
-        default=None,
+        values=["rsa", "ed25519", ""],
+        default="",
         scope=Scope.settings,
         help="Key type for generating an SSH key for accessing the lab. "
              "If set to None, the key handling should be done via the lab "
@@ -450,6 +450,7 @@ class HastexoXBlock(XBlock,
         node.set('stack_user_name', self.stack_user_name)
         node.set('stack_protocol', self.stack_protocol)
         node.set('stack_template_path', self.stack_template_path or '')
+        node.set('stack_key_type', self.stack_key_type)
         node.set('launch_timeout', str(self.launch_timeout or ''))
         node.set('suspend_timeout', str(self.suspend_timeout or ''))
         node.set('hook_script', self.hook_script or '')

--- a/hastexo/provider.py
+++ b/hastexo/provider.py
@@ -259,7 +259,7 @@ class OpenstackProvider(Provider):
         return {"status": status,
                 "outputs": outputs}
 
-    def create_stack(self, name, run, key_type=None):
+    def create_stack(self, name, run, key_type=""):
         if not self.template:
             raise ProviderException("Template not set for provider %s." %
                                     self.name)

--- a/tests/unit/test_hastexo.py
+++ b/tests/unit/test_hastexo.py
@@ -496,7 +496,7 @@ class TestHastexoXBlock(TestCase):
             {"stack_id": stack.id,
              "reset": False,
              "learner_id": stack.learner.id,
-             "stack_key_type": None}
+             "stack_key_type": ""}
         )
         self.assertEqual(response["status"], "LAUNCH_PENDING")
 

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -318,7 +318,7 @@ class TestOpenstackProvider(TestCase):
         with self.assertRaises(ProviderException):
             provider = Provider.init(self.provider_name)
             provider.create_stack(
-                self.stack_name, self.stack_run, key_type=None)
+                self.stack_name, self.stack_run, key_type="")
 
     @ddt.data('rsa', 'ed25519')
     def test_create_stack_generate_keys(self, key_type):
@@ -396,7 +396,7 @@ class TestOpenstackProvider(TestCase):
         provider.set_template(self.stack_template)
         provider.set_environment(self.stack_environment)
         stack = provider.create_stack(
-            self.stack_name, self.stack_run, key_type=None)
+            self.stack_name, self.stack_run, key_type="")
 
         # Assertions
         self.assertIsInstance(stack, dict)
@@ -429,7 +429,7 @@ class TestOpenstackProvider(TestCase):
             provider = Provider.init(self.provider_name)
             provider.set_template(self.stack_template)
             provider.create_stack(
-                self.stack_name, self.stack_run, key_type=None)
+                self.stack_name, self.stack_run, key_type="")
 
     @ddt.data(*HEAT_EXCEPTIONS)
     def test_create_stack_exception_on_get(self, heat_exception):
@@ -448,7 +448,7 @@ class TestOpenstackProvider(TestCase):
             provider = Provider.init(self.provider_name)
             provider.set_template(self.stack_template)
             provider.create_stack(
-                self.stack_name, self.stack_run, key_type=None)
+                self.stack_name, self.stack_run, key_type="")
 
     def test_create_stack_not_found_on_get(self):
         # Setup
@@ -466,7 +466,7 @@ class TestOpenstackProvider(TestCase):
             provider = Provider.init(self.provider_name)
             provider.set_template(self.stack_template)
             provider.create_stack(
-                self.stack_name, self.stack_run, key_type=None)
+                self.stack_name, self.stack_run, key_type="")
 
     def test_create_stack_failure(self):
         # Setup
@@ -483,7 +483,7 @@ class TestOpenstackProvider(TestCase):
             provider = Provider.init(self.provider_name)
             provider.set_template(self.stack_template)
             provider.create_stack(
-                self.stack_name, self.stack_run, key_type=None)
+                self.stack_name, self.stack_run, key_type="")
 
     def test_resume_stack_with_no_reboots(self):
         # Setup

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -131,7 +131,7 @@ class HastexoTestCase(TestCase):
             "stack_id": stack.id,
             "reset": False,
             "learner_id": self.learner.id,
-            "stack_key_type": None
+            "stack_key_type": ""
         }
 
         # Patchers
@@ -212,7 +212,7 @@ class TestLaunchStackTask(HastexoTestCase):
         provider.create_stack.assert_called_with(
             self.stack_name,
             self.stack_run,
-            key_type=None
+            key_type=""
         )
         self.mocks["ssh_to"].assert_called_with(
             self.stack_user_name,
@@ -279,7 +279,7 @@ class TestLaunchStackTask(HastexoTestCase):
         provider.create_stack.assert_called_with(
             self.stack_name,
             self.stack_run,
-            key_type=None
+            key_type=""
         )
         self.mocks["ssh_to"].assert_called_with(
             self.stack_user_name,
@@ -590,7 +590,7 @@ class TestLaunchStackTask(HastexoTestCase):
         provider.create_stack.assert_called_with(
             self.stack_name,
             self.stack_run,
-            key_type=None
+            key_type=""
         )
 
     def test_use_next_provider_if_first_is_disabled(self):
@@ -620,7 +620,7 @@ class TestLaunchStackTask(HastexoTestCase):
         provider2.create_stack.assert_called_with(
             self.stack_name,
             self.stack_run,
-            key_type=None
+            key_type=""
         )
 
     def test_use_next_provider_if_first_is_full(self):
@@ -659,7 +659,7 @@ class TestLaunchStackTask(HastexoTestCase):
         provider2.create_stack.assert_called_with(
             self.stack_name,
             self.stack_run,
-            key_type=None
+            key_type=""
         )
 
     def test_all_providers_full(self):
@@ -722,12 +722,12 @@ class TestLaunchStackTask(HastexoTestCase):
         provider1.create_stack.assert_called_with(
             self.stack_name,
             self.stack_run,
-            key_type=None
+            key_type=""
         )
         provider2.create_stack.assert_called_with(
             self.stack_name,
             self.stack_run,
-            key_type=None
+            key_type=""
         )
 
     def test_dont_use_next_provider_if_timeout(self):
@@ -791,7 +791,7 @@ class TestLaunchStackTask(HastexoTestCase):
             m.create_stack.assert_called_with(
                 self.stack_name,
                 self.stack_run,
-                key_type=None,
+                key_type="",
             )
 
     def test_only_one_provider_configured(self):


### PR DESCRIPTION
Use an empty string instead on `None` as a default option for the `stack_key_type` attribute so Studio will allow resetting the value.

In addition, include the attribute in the Studio export.