### PR TITLE
docs: Fix README reference to stack_protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,10 +479,11 @@ configured with the following attributes:
 * `stack_user_name`: The name of the user that the Xblock will use to connect
   to the environment, as specified in the orchestration template.
 
-* `protocol`: One of 'ssh', 'rdp', or 'vnc'.  This defines the protocol that
-  will be used to connect to the environment.  The default is 'ssh'.
-
 The following are optional:
+
+* `stack_protocol`: One of `ssh`, `rdp`, or `vnc`. This defines the
+  protocol that will be used to connect to the environment. The
+  default is `ssh`.
 
 * `stack_template_path`: The static asset path to the orchestration template,
   if not specified per provider below.
@@ -561,7 +562,7 @@ For example, in XML:
   <hastexo xmlns:option="http://code.edx.org/xblock/option"
     url_name="lab_introduction"
     stack_user_name="training"
-    protocol="rdp">
+    stack_protocol="rdp">
     <option:providers>
       - name: provider1
         capacity: 20


### PR DESCRIPTION
The parameter which we use to specify the protocol to connect to the stack has always been named `stack_protocol` since its inception in 5d8fa14729a5fb90f1a31e8864542b43af65432a.

For some reason, it ended up in the README as `protocol` in f82d0d83e06cc272a5b89a19e23fa603d671cee2, and this was never caught or fixed.

Fix that reference, and also move it from the list of required parameters to that of optional ones (since it has a default, `ssh`).