### PR TITLE
fix: Fix private key getting lost on stack resume failure

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+Unreleased
+-------------------------
+* [Bug fix] Fix private key getting lost after a stack resume failure.
+  Make sure we keep the stack key in place when running cleanup on
+  a stack that failed to resume.
+
 Version 7.7.2 (2023-09-15)
 -------------------------
 * [Bug fix] Fix editing the `stack_key_type` field in Studio; include

--- a/hastexo/tasks.py
+++ b/hastexo/tasks.py
@@ -255,12 +255,6 @@ class LaunchStackTask(HastexoTask):
         except LaunchStackFailed as e:
             logger.error(e.error_msg)
 
-            # In case of failure, only return the provider if this was a failed
-            # resume attempt.
-            provider_name = ""
-            if e.suspend:
-                provider_name = e.provider.name
-
             stack_data = {
                 'status': e.status,
                 'error_msg': textwrap.shorten(e.error_msg, width=256),
@@ -268,8 +262,14 @@ class LaunchStackTask(HastexoTask):
                 'user': "",
                 'key': "",
                 'password': "",
-                'provider': provider_name
+                'provider': ""
             }
+
+            # In case of a failed resume attempt, return the provider
+            # and keep the key in place so that the learner can retry.
+            if e.suspend:
+                stack_data['provider'] = e.provider.name
+                stack_data.pop('key')
 
             # Roll back in case of failure
             self.cleanup_stack(e)

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -544,6 +544,7 @@ class TestLaunchStackTask(HastexoTestCase):
         # Assertions
         self.assertEqual(stack.status, "RESUME_FAILED")
         self.assertEqual(stack.provider, self.providers[1]["name"])
+        self.assertEqual(self.stack_key, stack.key)
         provider.suspend_stack.assert_called()
 
     def test_undefined_capacity(self):
@@ -1058,6 +1059,10 @@ class TestLaunchStackTask(HastexoTestCase):
         # provider should still be unchanged.
         self.assertEqual(stack.provider, self.providers[1]["name"])
 
+        # When resume fails, we should still have the private key
+        # of the stack.
+        self.assertEqual(self.stack_key, stack.key)
+
     def test_resumed_stack_has_no_ip(self):
         # Setup
         provider = self.mock_providers[1]
@@ -1083,6 +1088,7 @@ class TestLaunchStackTask(HastexoTestCase):
         # Assertions
         self.assertEqual(stack.status, "RESUME_FAILED")
         self.assertEqual(stack.provider, self.providers[1]["name"])
+        self.assertEqual(self.stack_key, stack.key)
         provider.suspend_stack.assert_called()
 
     def test_timeout_resuming_stack(self):
@@ -1108,6 +1114,7 @@ class TestLaunchStackTask(HastexoTestCase):
         # Assertions
         self.assertEqual(stack.status, "LAUNCH_TIMEOUT")
         self.assertEqual(stack.provider, self.providers[1]["name"])
+        self.assertEqual(self.stack_key, stack.key)
 
     def test_resume_hook_empty(self):
         # Setup
@@ -1280,6 +1287,7 @@ class TestLaunchStackTask(HastexoTestCase):
 
         # Assertions
         self.assertEqual(stack.status, "CREATE_FAILED")
+        self.assertEqual('', stack.key)
         provider.delete_stack.assert_called_with(
             self.stack_name, False
         )
@@ -1304,6 +1312,7 @@ class TestLaunchStackTask(HastexoTestCase):
 
         # Assertions
         self.assertEqual(stack.status, "CREATE_FAILED")
+        self.assertEqual('', stack.key)
         provider.delete_stack.assert_called_with(
             self.stack_name, False
         )


### PR DESCRIPTION
Starting with v7.7.1, we are fetching the private key from the database. In case of a resume failure, we need to keep the key in place when running the cleanup step after the failed resume so that the learner will not lose access to the lab altogether.