### PR TITLE
build: Add pip 23.2.1 to the GitHub Actions workflow matrix

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -17,6 +17,7 @@ jobs:
         pip-version:
           - 22.0.4
           - 23.0.1
+          - 23.2.1
 
     steps:
     - name: Check out code


### PR DESCRIPTION
As of Open edX Quince/Tutor 17, the Tutor Dockerfile installs pip 23.2.1. Update the GitHub Actions workflow matrix to ensure that our dependencies don't break with that pip version.