### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -17,6 +17,10 @@ jobs:
         pip-version:
           - 22.0.4
           - 23.0.1
+          - 23.2.1
+        include:
+          - python-version: '3.12'
+            pip-version: '23.2.1'
 
     steps:
     - name: Check out code
@@ -27,7 +31,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install "tox<4" tox-gh-actions tox-pip-version
+        pip install "tox<4" tox-gh-actions tox-pip-version setuptools
     - env:
         TOX_PIP_VERSION: ${{ matrix.pip-version }}
       name: Test with tox (pip ${{ matrix.pip-version }})

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+Unreleased
+-------------------------
+* [Enhancement] Add support for Python 3.12.
+
 Version 7.9.1 (2024-02-14)
 -------------------------
 * [Bug fix] Don't allow accessing a fullscreen lab directly from a URL,

--- a/hastexo/__init__.py
+++ b/hastexo/__init__.py
@@ -1,8 +1,8 @@
-import pkg_resources
+from importlib import metadata
 # __version__ attribute as suggested by (deferred) PEP 396:
 # https://www.python.org/dev/peps/pep-0396/
 #
 # Single-source package definition as suggested (among several
 # options) by:
 # https://packaging.python.org/guides/single-sourcing-package-version/
-__version__ = pkg_resources.get_distribution('hastexo-xblock').version
+__version__ = metadata.version('hastexo-xblock')

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -1,7 +1,6 @@
 import time
 import logging
 import os
-import pkg_resources
 import re
 import string
 import textwrap
@@ -621,7 +620,7 @@ class HastexoXBlock(XBlock,
         lang_code = translation.get_language()
         if lang_code and lang_code in SUPPORTED_LANGUAGES:
             text_js_url = f'public/js/translations/{lang_code}/text.js'
-            if pkg_resources.resource_exists(loader.module_name, text_js_url):
+            if os.path.exists(os.path.join('hastexo', text_js_url)):
                 js_urls["text_js_url"] = self.runtime.local_resource_url(
                     self, text_js_url)
         else:

--- a/requirements/setup.txt
+++ b/requirements/setup.txt
@@ -1,3 +1,3 @@
 -r base.txt
-setuptools-scm<6
+setuptools-scm
 bumpversion

--- a/setup.py
+++ b/setup.py
@@ -77,5 +77,5 @@ setup(
                                "migrations",
                                "translations",
                                "locale"]),
-    setup_requires=['setuptools-scm<6'],
+    setup_requires=['setuptools-scm'],
 )

--- a/tests/unit/test_admin.py
+++ b/tests/unit/test_admin.py
@@ -157,7 +157,7 @@ class TestHastexoStackAdmin(TestCase):
         stack.status = 'SUSPEND_COMPLETE'
         stack.save(update_fields=["status"])
         logs = StackLog.objects.filter(stack_id=self.stack.id)
-        self.assertEquals(logs.count(), 4)
+        self.assertEqual(logs.count(), 4)
 
         data = {
             'action': 'clear_stacklog', '_selected_action': [self.stack.id, ]}
@@ -166,4 +166,4 @@ class TestHastexoStackAdmin(TestCase):
         self.assertEqual(response.status_code, 200)
 
         logs = StackLog.objects.filter(stack_id=self.stack.id)
-        self.assertEquals(logs.count(), 0)
+        self.assertEqual(logs.count(), 0)

--- a/tests/unit/test_hastexo.py
+++ b/tests/unit/test_hastexo.py
@@ -1,7 +1,6 @@
 import time
 import json
 import textwrap
-import pkg_resources
 import os
 
 from hastexo.models import Stack
@@ -50,13 +49,9 @@ class TestHastexoXBlockHTML(TestCase):
     """
 
     def test_static(self):
-        static_files = ['main.html']
+        static_files = ['main.html', 'lab.html']
         for static_file in static_files:
-            source = pkg_resources.resource_stream(
-                'hastexo',
-                os.path.join('static', 'html', static_file)
-            )
-            etree.parse(source,
+            etree.parse(os.path.join('hastexo', 'static', 'html', static_file),
                         etree.HTMLParser(recover=False))
 
 

--- a/tests/unit/test_openstack.py
+++ b/tests/unit/test_openstack.py
@@ -102,7 +102,7 @@ class TestHeatWrapper(TestOpenStackWrapper):
                 wrapper,
                 get_keystone_auth=mock_get_keystone_auth):
             wrapper.get_client()
-        self.mocks["heat_client"].Client.called_with(
+        self.mocks["heat_client"].Client.assert_called_with(
             "1",
             auth_url=self.credentials['os_auth_url'],
             session="sess",
@@ -129,8 +129,8 @@ class TestNovaWrapper(TestOpenStackWrapper):
                 wrapper,
                 get_keystone_auth=mock_get_keystone_auth):
             wrapper.get_client()
-        self.mocks["nova_client"].Client.called_with(
-            "2.0",
+        self.mocks["nova_client"].Client.assert_called_with(
+            "2.2",
             self.credentials['os_username'],
             self.credentials['os_password'],
             project_id=self.credentials['os_project_id'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,pipdeptree{,-requirements},py{38,39,310,311}-xblock{17,18,19}-celery5
+envlist = flake8,pipdeptree{,-requirements},py{38,39,310,311,312}-xblock{17,18,19}-celery5
 
 [gh-actions]
 python =
@@ -7,6 +7,7 @@ python =
     3.9: flake8,pipdeptree,pipdeptree-requirements,py39
     3.10: flake8,pipdeptree,pipdeptree-requirements,py310
     3.11: flake8,pipdeptree,pipdeptree-requirements,py311
+    3.12: flake8,pipdeptree,pipdeptree-requirements,py312
 
 [flake8]
 ignore = E124,W504

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,pipdeptree{,-requirements},py{38,39,310,311}-xblock{15,16,17}-celery5
+envlist = flake8,pipdeptree{,-requirements},py{38,39,310,311}-xblock{17,18,19}-celery5
 
 [gh-actions]
 python =
@@ -28,10 +28,10 @@ exclude_lines =
 deps =
     -rrequirements/setup.txt
     -rrequirements/test.txt
-    xblock-sdk
-    xblock15: XBlock>=1.5,<1.6
-    xblock16: XBlock>=1.6,<1.7
+    xblock-sdk<0.9.0
     xblock17: XBlock>=1.7,<1.8
+    xblock18: XBlock>=1.8,<1.9
+    xblock19: XBlock>=1.9,<2
     celery5: celery>=5,<6
 commands =
     python run_tests.py []


### PR DESCRIPTION
-   Update test matrix:
    -  xblock-sdk v0.9.0 includes a breaking change for XBlock versions before 2.0 but there is no upper constraint included in the requirements for this for all XBlock versions. Thus, all our tests have been failing since the release of xblock-sdk==0.9.0 on 2024-03-21.
    -   Update our test matrix to include XBlock versions 1.7 / 1.8 / 1.9 and add an upper constraint for xblock-sdk.
    -   The Open edX Quince release is using XBlock v1.8, which does pin the xblock-sdk to v0.7.0 so in this case we only need to add the constrait to our test runs.

- Add support for Python 3.12