### PR TITLE
Improve error handling for missing Provider configurations

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 Unreleased
 -------------------------
+* [Enhancement] Add better error handling for missing Provider configuration.
 * [Enhancement] Add support for Python 3.12.
 
 Version 7.9.1 (2024-02-14)

--- a/hastexo/provider.py
+++ b/hastexo/provider.py
@@ -66,6 +66,9 @@ class Provider(object):
                 return OpenstackProvider(name, config, sleep_seconds)
             elif provider_type == "gcloud":
                 return GcloudProvider(name, config, sleep_seconds)
+        else:
+            raise ProviderException(
+                f"Configuration missing for provider: {name}")
 
     def __init__(self, name, config, sleep):
         self.name = name

--- a/tests/unit/test_provider.py
+++ b/tests/unit/test_provider.py
@@ -169,6 +169,12 @@ class TestOpenstackProvider(TestCase):
         self.assertNotEqual(provider.heat_c, None)
         self.assertNotEqual(provider.nova_c, None)
 
+    def test_init_missing_configuration(self):
+        self.settings["providers"].pop(self.provider_name)
+
+        with self.assertRaises(ProviderException):
+            Provider.init(self.provider_name)
+
     def test_generate_ssh_keys(self):
         provider = Provider.init(self.provider_name)
 


### PR DESCRIPTION
Throw a ProviderException when a provider configuration is missing but the Provider is linked to an existing Stack.