### PR TITLE
Stop installing the XBlock in editable mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+Unreleased
+-------------------------
+* [Bug fix] Stop installing the XBlock in editable mode with `-e .`
+
 Version 7.10.0 (2024-04-15)
 -------------------------
 * [Enhancement] Add better error handling for missing Provider configuration.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,4 +24,3 @@ twisted<23.8.0 # drop this restriction once we drop Python 3.8 and 3.9 support
 mysqlclient<=2.2.1  # keep in sync with edx-platform
 jsonfield>=3.1.0,<4   # keep in sync with edx-platform
 pyguacamole>=0.11
--e .


### PR DESCRIPTION
Drop the `-e .` from `requirements/base.txt`