### PR TITLE
Bump GitHub Actions version references

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -35,11 +35,12 @@ jobs:
       name: Test with tox (pip ${{ matrix.pip-version }})
       run: tox
     - name: Upload coverage data
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: coverage-${{ matrix.python-version }}
-        path: .coverage*
+        name: coverage-${{ matrix.python-version }}-${{ matrix.pip-version }}
+        path: '.coverage.*'
         retention-days: 1
+        include-hidden-files: true
 
   report:
     needs: build
@@ -49,7 +50,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v1
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
     - name: Set up Python 3.8
       uses: actions/setup-python@v4
       with:
@@ -59,13 +60,13 @@ jobs:
         pip install coverage
     - name: Compile coverage data
       run: |
-        mv coverage-*/.coverage* .
+        mv coverage-*/.coverage.* .
         coverage combine
         coverage html
         coverage xml
         coverage report
     - name: Upload htmlcov archive
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: htmlcov
         path: htmlcov

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -52,7 +52,7 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@v4
     - name: Set up Python 3.8
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -72,4 +72,4 @@ jobs:
         path: htmlcov
         retention-days: 7
     - name: Upload to codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -48,7 +48,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
     - name: Download artifacts
       uses: actions/download-artifact@v4
     - name: Set up Python 3.8


### PR DESCRIPTION
Bump the tag reference for the following GitHub Actions to their latest versions:

- `actions/upload-artifact`
- `actions/download-artifact`
- `actions/checkout`
- `actions/setup-python`
- `codecov/codecov-action`

This fixes the `report` job.