### PR TITLE
Bump version: 7.13.0 → 8.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 7.13.0
+current_version = 8.0.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(rc(?P<rc>\d+))?
 serialize = 
 	{major}.{minor}.{patch}rc{rc}

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-Unreleased
+Version 8.0.0 (2024-10-16)
 -------------------------
 * Drop support for Python 3.8 and `XBlock<2` (and, as a consequence,
   any Open edX releases prior to Redwood).

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ two steps:
    `OPENEDX_EXTRA_PIP_REQUIREMENTS` list in `config.yml`:
    ```
    OPENEDX_EXTRA_PIP_REQUIREMENTS:
-     - "hastexo-xblock==7.13.0"
+     - "hastexo-xblock==8.0.0"
    ```
    For additional information, please refer to the [official
    documentation](https://docs.tutor.overhang.io/configuration.html#installing-extra-xblocks-and-requirements).


### PR DESCRIPTION
With dropping support for Python 3.8 and with that for releases before Redwood, we need to bump the major version.