### PR TITLE
Restrict access to fullscreen labs directly from an URL

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+Unreleased
+-------------------------
+* [Bug fix] Add more authentication checks when accessing a fullscreen
+  lab directly from an URL. Return a 401 when user is not authenticated
+  on the platform.
+
 Version 8.0.0 (2024-10-16)
 -------------------------
 * Drop support for Python 3.8 and `XBlock<2` (and, as a consequence,

--- a/hastexo/hastexo.py
+++ b/hastexo/hastexo.py
@@ -663,7 +663,11 @@ class HastexoXBlock(XBlock,
         """
         The fullscreen lab view, opened in a new browser window.
         """
-        if 'sessionid' not in request.cookies:
+
+        # Properly authenticated requests contain two session cookies:
+        # sessionid and edxloggedin.
+        # If either of them isn't present, return HTTP 401 immediately.
+        if not all(c in request.cookies for c in ('sessionid', 'edxloggedin')):
             return Response(status=401, body="Unauthorized")
 
         # Get context

--- a/tests/unit/test_hastexo.py
+++ b/tests/unit/test_hastexo.py
@@ -1661,6 +1661,7 @@ class TestHastexoXBlock(TestCase):
         with patch('webob.Request') as request:
             request.cookies = Mock()
             request.cookies = {
+                'edxloggedin': 'true',
                 'sessionid': 'fake_sessionid',
                 'csrftoken': 'fake_csrf_token'}
             response = self.block.launch_new_window(request)


### PR DESCRIPTION
Add more authentication checks when acessing a fullscreen lab direclty from an URL. Return a 401 when the user is not authenticated in the platfrom.