### PR TITLE
Add support for resizing the lab window

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+Unreleased
+-------------------------
+* [Enhancement] Add the possibility to dynamically resize the lab on the 
+  LMS page. For RDP connections, implement the options provided by 
+  Apache Guacamole, to `display-update` or `reconnect` (the default), 
+  when the client display size changes. The given options are explained 
+  in more detail in the README.
+
 Version 8.2.0 (2025-01-03)
 -------------------------
 * [Enhancement] Add support for Apache Guacamole 1.5.5;

--- a/README.md
+++ b/README.md
@@ -198,6 +198,15 @@ This is a brief explanation of each:
 * `enable_fullscreen`: An option to allow learners to launch a lab in fullsceen mode,
   in a separate browser window. (Default: `false`)
 
+* `lab_resize_method`: A [display setting](https://guacamole.apache.org/doc/1.5.5/gug/configuring-guacamole.html#rdp-display-settings) for RDP connections to update the RDP server
+  when the width and height of the client display changes. Possible values are:
+
+  * `display-update` *Only supported with Windows RDP 8.1 or xrdp 0.10.1 (and higher)*. 
+    Uses the "Display Update" channel to request the server to change the display size.
+
+  * `reconnect` (the default) Automatically disconnects the RDP session when the client 
+    display size has changed, and reconnects with the new size.
+
 * `lab_usage_limit`: Allocate limited time per user for labs across the platform,
   in seconds. (Default is `None`, meaning there is no time limit).
 

--- a/hastexo/common.py
+++ b/hastexo/common.py
@@ -185,7 +185,8 @@ DEFAULT_SETTINGS = {
     "providers": {},
     "guacamole_js_version": '1.5.5',
     "lab_usage_limit": None,
-    "lab_usage_limit_breach_policy": None
+    "lab_usage_limit_breach_policy": None,
+    "lab_resize_method": "reconnect"
 }
 
 SUPPORTED_LANGUAGES = [

--- a/hastexo/public/js/client.js
+++ b/hastexo/public/js/client.js
@@ -240,6 +240,10 @@ function HastexoGuacamoleClient(configuration) {
 
         onidle(pause) {
             return pause;
+        },
+
+        sendSize(height, width) {
+            guac_client.sendSize(height, width);
         }
     }
 

--- a/hastexo/public/js/main.js
+++ b/hastexo/public/js/main.js
@@ -90,6 +90,15 @@ function HastexoXBlock(runtime, element, configuration) {
         /* Show the terminal.  */
         $("#terminal").append(terminal_element);
 
+        // Observe the lab size in the browser and adjust when necessary
+        var lab = $('#terminal')[0];
+        const resizeObserver = new ResizeObserver(entries => {
+            for (const entry of entries) {
+                terminal_client.sendSize(entry.contentRect.width, entry.contentRect.height);
+            }
+        });
+        resizeObserver.observe(lab);
+
         /* Disconnect on tab close. */
         window.onunload = function() {
             terminal_client.disconnect();

--- a/hastexo_guacamole_client/consumers.py
+++ b/hastexo_guacamole_client/consumers.py
@@ -38,6 +38,7 @@ class GuacamoleWebSocketConsumer(AsyncWebsocketConsumer):
             protocol=stack.protocol,
             width=params.get('width', [1024])[0],
             height=params.get('height', [768])[0],
+            resize_method=settings.get("lab_resize_method"),
             hostname=stack.ip,
             port=params.get('port', [default_port])[0],
             username=stack.user,


### PR DESCRIPTION
Add an observer to the JavaScript code to detect lab size changes on the LMS page and send the new dimensions to the guacamole client.