### PR TITLE
build: Use GitLab Pages for htmlcov

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,8 +29,12 @@ coverage:
     - python -m coverage combine
     - python -m coverage html
     - python -m coverage report
+    - mv htmlcov public
   coverage: '/TOTAL.*\s+(\d+\.\d+%)$/'
   artifacts:
     paths:
-      - htmlcov
+      - public
+    expire_in: 1 week
+  pages:
+    path_prefix: "$CI_COMMIT_BRANCH"
     expire_in: 1 week


### PR DESCRIPTION
For GitLab CI pipelines, rather than making the coverage HTML output
just a downloadable artifact, also create a GitLab page.

Once run in a GitLab environment, the htmlcov data is available from
https://<domain-name>/<branch-name>/index.html
where <domain-name> is defined in the GitLab project settings.
