### PR TITLE
Update versioning in setup.py

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -14,3 +14,5 @@ search = Unreleased
 replace = Version {new_version} ({now:%Y-%m-%d})
 
 [bumpversion:file:README.md]
+
+[bumpversion:file:setup.py]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 Unreleased
 -------------------------
+* [Chore] Switch to manual versioning in `setup.py` instead using
+  `setuptools_scm` and bump it automatically via `bumpversion` whenever
+  we tag a new release.
 * [Enhancement] Update requirements for Open edX Teak release. 
 
 Version 8.4.0 (2025-05-21)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def package_data(pkg, roots):
 
 setup(
     name='hastexo-xblock',
-    use_scm_version=True,
+    version='8.4.0',
     description='hastexo XBlock: '
                 'Makes arbitrarily complex lab environments '
                 'available on an Open edX LMS',
@@ -88,5 +88,4 @@ setup(
                                "migrations",
                                "translations",
                                "locale"]),
-    setup_requires=['setuptools-scm'],
 )


### PR DESCRIPTION
`setuptools-scm` usage in `setup.py` via `setup_requires` has been deprecated.
(https://setuptools.pypa.io/en/stable/history.html#v58-3-0) (https://pypi.org/project/setuptools-scm/7.0.1/)

Use manual versioning in `setup.py` instead
and bump it automatically via `bumpversion` whenever we tag a new release.