### PR TITLE
Add upper constraint to oslo.i18n dependency

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+-------------------------
+* [Bug fix] Add upper contraint to `oslo.i18n` dependency to avoid
+  pulling in a newer, incompatible version.
+
 Version 8.5.0 (2025-07-30)
 -------------------------
 * [Enhancement] Update requirements for Open edX Teak release. 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,6 +10,7 @@ os-client-config<=2.1
 oslo.config<=9.7.1
 oslo.serialization<=5.5
 oslo.utils<=7.4
+oslo.i18n<6.6
 paramiko>=3.5.1,<4
 pymongo<=4.4.0 # keep in sync with edx-platform
 python-heatclient<=4.0

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         'oslo.serialization<=5.5',
         'oslo.utils<=7.4',
         'oslo.config<=9.7.1',
+        'oslo.i18n<6.6',
         'paramiko>=3.5.0,<4',
         'python-heatclient<=4.0',
         'python-keystoneclient<=5.5',


### PR DESCRIPTION
Add upper constraint to oslo.i18n dependency to avoid pulling in a newer, incompatible version.