### PR TITLE
build: Fix GitLab CI pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ py311:
   stage: build
   script:
     - pip install tox
-    - tox -e py311-flake8,py311-pipdeptree,py311-pipdeptree-requirements,py311-xblock40-celery5
+    - tox -e py311-flake8,py311-pipdeptree,py311-pipdeptree-requirements,py311-xblock50-celery5
   artifacts:
     paths:
       - .coverage*
@@ -16,7 +16,7 @@ py312:
   stage: build
   script:
     - pip install tox
-    - tox -e py312-flake8,py312-pipdeptree,py312-pipdeptree-requirements,py312-xblock40-celery5
+    - tox -e py312-flake8,py312-pipdeptree,py312-pipdeptree-requirements,py312-xblock50-celery5
   artifacts:
     paths:
       - .coverage*


### PR DESCRIPTION
Update the tox invocation so that it no longer tries testenvs that do not exist.