### PR TITLE
Documentation improvements

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 Unreleased
 -------------------------
 
-* Drop support for GCloud Provier.
+* Drop support for GCloud Provider.
   The Cloud Deployment Manager, which the current implementation is based on, will reach end of support on March 31, 2026.
   (https://docs.cloud.google.com/deployment-manager/docs)
 
@@ -30,7 +30,7 @@ Version 8.5.2 (2025-11-07)
 Version 8.5.1 (2025-09-19)
 -------------------------
 
-* [Bug fix] Add upper contraint to `oslo.i18n` dependency to avoid pulling in a newer, incompatible version.
+* [Bug fix] Add upper constraint to `oslo.i18n` dependency to avoid pulling in a newer, incompatible version.
 
 Version 8.5.0 (2025-07-30)
 -------------------------
@@ -66,7 +66,7 @@ Version 8.1.0 (2024-11-20)
 Version 8.0.1 (2024-11-13)
 -------------------------
 
-* [Bug fix] Add more authentication checks when accessing a fullscreen lab directly from an URL.
+* [Bug fix] Add more authentication checks when accessing a fullscreen lab directly from a URL.
   Return a 401 when user is not authenticated on the platform.
 
 Version 8.0.0 (2024-10-16)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,18 +1,19 @@
 Unreleased
 -------------------------
-* Drop support for GCloud Provier. The Cloud Deployment Manager,
-  which the current implementation is based on, will reach end of 
-  support on March 31, 2026.
+
+* Drop support for GCloud Provier.
+  The Cloud Deployment Manager, which the current implementation is based on, will reach end of support on March 31, 2026.
   (https://docs.cloud.google.com/deployment-manager/docs)
 
 Version 8.7.0 (2026-03-10)
 -------------------------
-* [Enhancement] Add an extra confirmation step to resetting
-  a lab. The learner now needs to type in a generated code
-  to confirm their lab reset.
+
+* [Enhancement] Add an extra confirmation step to resetting a lab.
+  The learner now needs to type in a generated code to confirm their lab reset.
 
 Version 8.6.0 (2026-02-16)
 -------------------------
+
 * [Enhancement] Update requirements for Open edX Ulmo release.
 
 Version 8.5.3 (2026-01-19)
@@ -22,400 +23,360 @@ Version 8.5.3 (2026-01-19)
 
 Version 8.5.2 (2025-11-07)
 -------------------------
-* [Bug fix]
-  Use the `score` value to define correctness for this XBlock instead of
-  the progress check result. This will allow to properly evaluate the
-  correctness of the XBlock when an instructor overrides a score for 
-  a learner.
+
+* [Bug fix] Use the `score` value to define correctness for this XBlock instead of the progress check result.
+  This will allow to properly evaluate the correctness of the XBlock when an instructor overrides a score for a learner.
 
 Version 8.5.1 (2025-09-19)
 -------------------------
-* [Bug fix] Add upper contraint to `oslo.i18n` dependency to avoid
-  pulling in a newer, incompatible version.
+
+* [Bug fix] Add upper contraint to `oslo.i18n` dependency to avoid pulling in a newer, incompatible version.
 
 Version 8.5.0 (2025-07-30)
 -------------------------
-* [Enhancement] Update requirements for Open edX Teak release. 
+
+* [Enhancement] Update requirements for Open edX Teak release.
 
 Version 8.4.0 (2025-05-21)
 -------------------------
-* [Enhancement] Make sure that all the package data files and correct
-  versions of requirements are installed with the XBlock. When deploying
-  with Tutor, the requirements from `requirements.txt` are not installed
-  when building the `openedx` image. Expand the `install_requires` list
-  in `setup.py` to match the necessary versions from `requirements.txt`.
+
+* [Enhancement] Make sure that all the package data files and correct versions of requirements are installed with the XBlock.
+  When deploying with Tutor, the requirements from `requirements.txt` are not installed when building the `openedx` image.
+  Expand the `install_requires` list in `setup.py` to match the necessary versions from `requirements.txt`.
 
 Version 8.3.0 (2025-02-07)
 -------------------------
-* [Enhancement] Add the possibility to dynamically resize the lab on the 
-  LMS page. For RDP connections, implement the options provided by 
-  Apache Guacamole, to `display-update` or `reconnect` (the default), 
-  when the client display size changes. The given options are explained 
-  in more detail in the README.
+
+* [Enhancement] Add the possibility to dynamically resize the lab on the LMS page.
+  For RDP connections, implement the options provided by Apache Guacamole, to `display-update` or `reconnect` (the default), when the client display size changes.
+  The given options are explained in more detail in the README.
 
 Version 8.2.0 (2025-01-03)
 -------------------------
+
 * [Enhancement] Add support for Apache Guacamole 1.5.5;
   make it the new default version.
-* [Enhancement] Update requirements for Open edX Sumac release. 
+* [Enhancement] Update requirements for Open edX Sumac release.
 
 Version 8.1.0 (2024-11-20)
 -------------------------
+
 * [Chore] Update requirements.
 
 Version 8.0.1 (2024-11-13)
 -------------------------
-* [Bug fix] Add more authentication checks when accessing a fullscreen
-  lab directly from an URL. Return a 401 when user is not authenticated
-  on the platform.
+
+* [Bug fix] Add more authentication checks when accessing a fullscreen lab directly from an URL.
+  Return a 401 when user is not authenticated on the platform.
 
 Version 8.0.0 (2024-10-16)
 -------------------------
-* Drop support for Python 3.8 and `XBlock<2` (and, as a consequence,
-  any Open edX releases prior to Redwood).
+
+* Drop support for Python 3.8 and `XBlock<2` (and, as a consequence, any Open edX releases prior to Redwood).
 
 Version 7.13.0 (2024-09-27)
 -------------------------
-* [Enhancement] Enable `show_in_read_only_mode` XBlock attribute
-  to allow instuctors to use this XBlock while masquerading
-  as a specific learner.
+
+* [Enhancement] Enable `show_in_read_only_mode` XBlock attribute to allow instuctors to use this XBlock while masquerading as a specific learner.
 
 Version 7.12.0 (2024-08-06)
 -------------------------
+
 * [Enhancement] Add support for the Open edX Redwood release.
 
 Version 7.11.0 (2024-05-06)
 -------------------------
+
 * [Enhancement] Update to a newer Twisted version.
 * [Enhancement] Update to a newer Paramiko version.
 
 Version 7.10.1 (2024-04-23)
 -------------------------
+
 * [Bug fix] Stop installing the XBlock in editable mode with `-e .`
 
 Version 7.10.0 (2024-04-15)
 -------------------------
+
 * [Enhancement] Add better error handling for missing Provider configuration.
 * [Enhancement] Add support for Python 3.12.
 
 Version 7.9.1 (2024-02-14)
 -------------------------
-* [Bug fix] Don't allow accessing a fullscreen lab directly from a URL,
-  when the user is unauthenticated. Return a 401 right away when attempted.
+
+* [Bug fix] Don't allow accessing a fullscreen lab directly from a URL, when the user is unauthenticated.
+  Return a 401 right away when attempted.
 
 Version 7.9.0 (2024-01-11)
 -------------------------
+
 * [Enhancement] Add support for Apache Guacamole 1.5.4;
   make it the new default version.
 * [Enhancement] Update requirements for Open edX Quince release.
 
 Version 7.8.1 (2023-12-18)
 -------------------------
+
 * [Bug fix] Include missing XBlock attributes in a course export.
-* [Bug fix] Fix `enable_fullscreen` setting overrides via the XBlock
-  attribute.
+* [Bug fix] Fix `enable_fullscreen` setting overrides via the XBlock attribute.
 
 Version 7.8.0 (2023-12-13)
 -------------------------
+
 * [Enhancement] Add an option to launch the lab in a new window.
 
 Version 7.7.3 (2023-12-04)
 -------------------------
+
 * [Bug fix] Fix private key getting lost after a stack resume failure.
-  Make sure we keep the stack key in place when running cleanup on
-  a stack that failed to resume.
+  Make sure we keep the stack key in place when running cleanup on a stack that failed to resume.
 
 Version 7.7.2 (2023-09-15)
 -------------------------
-* [Bug fix] Fix editing the `stack_key_type` field in Studio; include
-  the attribute in Studio export.
+
+* [Bug fix] Fix editing the `stack_key_type` field in Studio; include the attribute in Studio export.
 * [Bug fix] Add better handling for SSH key cleanup when deleting stacks.
 
 Version 7.7.1 (2023-09-13)
 -------------------------
-* [Bug fix] Fix resuming a lab stack when the `stack_key_type`
-  attribute is used and the SSH key for the lab is generated
-  by the XBlock.
-* [Bug fix] Restrict Twisted dependency to `twisted<23.8.0` to remain
-  installable on Python 3.8 and 3.9.
+
+* [Bug fix] Fix resuming a lab stack when the `stack_key_type` attribute is used and the SSH key for the lab is generated by the XBlock.
+* [Bug fix] Restrict Twisted dependency to `twisted<23.8.0` to remain installable on Python 3.8 and 3.9.
 
 Version 7.7.0 (2023-08-24)
 -------------------------
-* [Enhancement] Add support for Ed25519 SSH keys by introducing
-  a new optional XBlock attribute `stack_key_type`. When used, it
-  is possible to generate either `RSA` or `Ed25519` key for the lab.
-  If set to `None`(default), the key handling should be done via the
-  lab template, as it has been so far.
+
+* [Enhancement] Add support for Ed25519 SSH keys by introducing a new optional XBlock attribute `stack_key_type`.
+  When used, it is possible to generate either `RSA` or `Ed25519` key for the lab.
+  If set to `None`(default), the key handling should be done via the lab template, as it has been so far.
 
 Version 7.6.0 (2023-06-26)
 -------------------------
+
 * [Enhancement] Add support for Apache Guacamole 1.5.2;
   make it the new default version.
 
 Version 7.5.0 (2023-03-14)
 -------------------------
+
 * [Enhancement] Update requirements for Open edX Olive release.
 
 Version 7.4.0 (2023-02-20)
 -------------------------
-* [Bug fix] Restore the `paste` functionality by addressing
-  the related changes in the `guacamole-js` library.
-* [Enhancement] Add support for copying text out from
-  the terminal using the Async Clipboard API.
-  This works on Mozilla Firefox at this time. Support
-  in other browsers may follow.
+
+* [Bug fix] Restore the `paste` functionality by addressing the related changes in the `guacamole-js` library.
+* [Enhancement] Add support for copying text out from the terminal using the Async Clipboard API.
+  This works on Mozilla Firefox at this time.
+  Support in other browsers may follow.
 
 Version 7.3.0 (2023-01-20)
 -------------------------
+
 * [Enhancement] Add internationalization support.
 
 Version 7.2.0 (2022-11-17)
 -------------------------
-* [Enhancement] Add learner email to stacklist view in the
-  admin page and include it in searchable fields.
+
+* [Enhancement] Add learner email to stacklist view in the admin page and include it in searchable fields.
 
 Version 7.1.0 (2022-11-07)
 -------------------------
-* [Enhancement] Add custom actions to the admin interface to
-  - clear the stacklog for selected stack(s),
-  - set status to `SUSPEND_COMPLETE` for selected stack(s).
-  
-  Clearing the stacklog will be particulary useful in cases
-  we need to "reset" a lab usage timer, since the
-  time is accumulated by the stacklog entries.
-  Setting a status to `SUSPEND_COMPLETE` is a common fix for
-  stacks that end up in unexpected states.
+
+* [Enhancement] Add custom actions to the admin interface to clear the stacklog for selected stack(s), and set status to `SUSPEND_COMPLETE` for selected stack(s).
+
+  Clearing the stacklog will be particulary useful in cases we need to "reset" a lab usage timer, since the time is accumulated by the stacklog entries.
+
+  Setting a status to `SUSPEND_COMPLETE` is a common fix for stacks that end up in unexpected states.
 
 Version 7.0.1 (2022-10-04)
-----------
-* [Bug fix] Retry `read_from_contentstore()`. Use `tenacity`'s
-  retry functionality for getting course information from contentstore.
+-------------------------
+
+* [Bug fix] Retry `read_from_contentstore()`.
+  Use `tenacity`'s retry functionality for getting course information from contentstore.
 
 Version 7.0.0 (2022-08-22)
 -------------------------
+
 * [Bug fix] From Celery 5.0.0 the legacy task API was discontinued.
-  This meant that the Task base class no longer automatically registered 
-  child tasks in Open edX Nutmeg (which uses Celery 5.2.6). 
+  This meant that the Task base class no longer automatically registered child tasks in Open edX Nutmeg (which uses Celery 5.2.6).
   Manually register the class-based tasks on the Celery app instance.
-* [BREAKING CHANGE] Update the `hastexo_guacamole_client` to
-  Channels 3. The asgi root application (`ASGI_APPLICATION`)
-  is now defined in the `asgi.py` file instead of `routing.py` file.
-  The asgi application now also checks for allowed hosts,
-  meaning if you want to allow the LMS to connect to labs via the `hastexo_guacamole_client`, the LMS host has to be listed in
-  `ALLOWED_HOSTS` at `hastexo_guacamole_client.settings.py`.
-* [Documentation] Remove obsolete deployment instructions for the
-  old “native” (Ansible-based) installation, and the old Devstack.
+* [BREAKING CHANGE] Update the `hastexo_guacamole_client` to Channels 3.
+  The asgi root application (`ASGI_APPLICATION`) is now defined in the `asgi.py` file instead of `routing.py` file.
+  The asgi application now also checks for allowed hosts, meaning if you want to allow the LMS to connect to labs via the `hastexo_guacamole_client`, the LMS host has to be listed in `ALLOWED_HOSTS` at `hastexo_guacamole_client.settings.py`.
+* [Documentation] Remove obsolete deployment instructions for the old "native" (Ansible-based) installation, and the old Devstack.
 
 Version 6.2.0 (2022-07-21)
 -------------------------
 
-* [Enhancement] Add an option to override the `suspend_timeout`
-  global setting via an XBlock attribute, in seconds.
+* [Enhancement] Add an option to override the `suspend_timeout` global setting via an XBlock attribute, in seconds.
 
 Version 6.1.5 (2022-07-13)
 -------------------------
 
-* [Bug fix] Fix migrations around the `lab_usage_limit` feature
-  introduced in 6.1.0. This unbreaks migrations in the event that some
-  stacks cannot be linked to an existing user account.
+* [Bug fix] Fix migrations around the `lab_usage_limit` feature introduced in 6.1.0.
+  This unbreaks migrations in the event that some stacks cannot be linked to an existing user account.
 
 Version 6.1.4 (2022-07-06)
 -------------------------
 
-* [Bug fix] Bring back `asgiref` constraint and lower
-  `Django` constraint. These need to be
-  in sync with the `channels` version requirements.
+* [Bug fix] Bring back `asgiref` constraint and lower `Django` constraint.
+  These need to be in sync with the `channels` version requirements.
 
 Version 6.1.3 (2022-06-29)
 -------------------------
 
-* [Bug fix] Add a check to the `add_user_foreign_key` migration
-  file to find stacks that are missing a link to a real user account.
-  If such stack(s) exist, do not attempt to apply the migration,
-  instead raise an exception and provide an error message with
-  guidance on how to proceed.
+* [Bug fix] Add a check to the `add_user_foreign_key` migration file to find stacks that are missing a link to a real user account.
+  If such stack(s) exist, do not attempt to apply the migration, instead raise an exception and provide an error message with guidance on how to proceed.
 
 Version 6.1.2 (2022-06-22)
 -------------------------
 
 * [Enhancement] Install a newer version of the Paramiko library.
-* [Bug fix] Set upper bounds for the `install_requires` list in
-  `setup.py`, to match those set in `requirements.txt`. This fixes a
-  version incompatibility problem when the package is installed by pip
-  version 20 and earlier, which would lead to
-  `pkg_resources.ContextualVersionConflict` errors when deployed on
-  Open edX Maple.
-* [Testing] Enhance the test matrix to include the pip versions used
-  in Open edX Maple (20.0.2) and Nutmeg (22.0.4), and use pipdeptree
-  to automatically flag dependency version inconsistencies.
+* [Bug fix] Set upper bounds for the `install_requires` list in `setup.py`, to match those set in `requirements.txt`.
+  This fixes a version incompatibility problem when the package is installed by pip version 20 and earlier, which would lead to `pkg_resources.ContextualVersionConflict` errors when deployed on Open edX Maple.
+* [Testing] Enhance the test matrix to include the pip versions used in Open edX Maple (20.0.2) and Nutmeg (22.0.4), and use pipdeptree to automatically flag dependency version inconsistencies.
 
 Version 6.1.1 (2022-04-25)
 -------------------------
-* [Enhancement] Add `hidden` option for spinning up a lab
-  environment in the background while the lab itself is hidden.
+
+* [Enhancement] Add `hidden` option for spinning up a lab environment in the background while the lab itself is hidden.
 
 Version 6.1.0 (2022-04-21)
 -------------------------
-* [Enhancement] Be more specific when raising the exception for
-  restricting lab access due to lab usage limit being reached.
-* [Enhancement] Add an option to track and limit a learners lab
-  usage. To support time tracking, link a learner to their stacks
-  across the platform by adding a Foreign Key field for user to
-  the Stack object.
-  Add configuration options for setting a time limit for using labs
-  (`lab_usage_limit`) in seconds and how to handle a breach of the
-  set limit (`lab_usage_limit_breach_policy`).
+
+* [Enhancement] Be more specific when raising the exception for restricting lab access due to lab usage limit being reached.
+* [Enhancement] Add an option to track and limit a learners lab usage.
+  To support time tracking, link a learner to their stacks across the platform by adding a Foreign Key field for user to the Stack object.
+  Add configuration options for setting a time limit for using labs (`lab_usage_limit`) in seconds and how to handle a breach of the set limit (`lab_usage_limit_breach_policy`).
 * [Testing] Include XBlock 1.6 in the test matrix.
 
 Version 6.0.1 (2022-03-14)
 -------------------------
-* [Documentation] Update README with improved instructions for Open
-  edX Maple (using Tutor) and Lilac (using edx-configuration).
+
+* [Documentation] Update README with improved instructions for Open edX Maple (using Tutor) and Lilac (using edx-configuration).
 
 Version 6.0.0rc0 (2022-02-23)
 -------------------------
-* [Bug fix] Don't fail to run if a listed provider is not
-  configured. Allow to move on to the next provider and log a
-  warning message for the provider initialisation failure.
-* [BREAKING CHANGE] Update the `GUACD_*` environment variables to
-  better suit a Tutor deployment. Rename the variables to
-  `GUACD_SERVICE_HOST` and `GUACD_SERVICE_PORT` to directly read
-  values set for the guacd service with the `tutor k8s` deployment.
-  Update the default values to support the `tutor local`/
-  `tutor dev` deployment.
-* [BREAKING CHANGE] Update dependencies that should be in sync with
-  `edx-platform` to support the `Maple` release.
-  As of 6.0, this XBlock only supports Open edX versions Maple and
-  higher. As the community has switched the supported deployment method
-  from edx-configuration playbooks to Tutor, this XBlock can also
-  be deployed with Tutor only. Instructions for the latter can be found
-  in the README.
-* [Enhancement] Add support for Tutor deployment, by dropping the
-  `wait_for_ping` logic.
-* [Enhancement] Add support for Apache Guacamole version `1.4.0`,
-  make it the new default.
-* [Enhancement] Make the `guacamole-common-js` library version
-  configurable by the `guacamole_js_version` setting.
-* [Bug fix] Fix unbalanced tags (`<p>` vs. `<div>`) in the static
-  `main.html` template.
+
+* [Bug fix] Don't fail to run if a listed provider is not configured.
+  Allow to move on to the next provider and log a warning message for the provider initialisation failure.
+* [BREAKING CHANGE] Update the `GUACD_*` environment variables to better suit a Tutor deployment.
+  Rename the variables to `GUACD_SERVICE_HOST` and `GUACD_SERVICE_PORT` to directly read values set for the guacd service with the `tutor k8s` deployment.
+  Update the default values to support the `tutor local`/`tutor dev` deployment.
+* [BREAKING CHANGE] Update dependencies that should be in sync with `edx-platform` to support the `Maple` release.
+  As of 6.0, this XBlock only supports Open edX versions Maple and higher.
+  As the community has switched the supported deployment method from edx-configuration playbooks to Tutor, this XBlock can also be deployed with Tutor only.
+  Instructions for the latter can be found in the README.
+* [Enhancement] Add support for Tutor deployment, by dropping the `wait_for_ping` logic.
+* [Enhancement] Add support for Apache Guacamole version `1.4.0`, make it the new default.
+* [Enhancement] Make the `guacamole-common-js` library version configurable by the `guacamole_js_version` setting.
+* [Bug fix] Fix unbalanced tags (`<p>` vs. `<div>`) in the static `main.html` template.
 * [Testing] Add basic HTML validation for static templates.
 
 Version 5.0.17 (2022-01-04)
 -------------------------
-* [Enhancement] Add constraints to Django version requirement for
-  the `hastexo_guacamole_client`.
+
+* [Enhancement] Add constraints to Django version requirement for the `hastexo_guacamole_client`.
 
 Version 5.0.16 (2021-09-01)
 -------------------------
-* [Bug fix] Make sure that any error message that is added to the
-  `error_msg` field of a stack, gets truncated before a stack update.
+
+* [Bug fix] Make sure that any error message that is added to the `error_msg` field of a stack, gets truncated before a stack update.
 * [Testing] Include XBlock 1.5 in the test matrix, remove XBlock 1.3.
-* [Testing] Include Python 3.9 in the test matrix, remove remnants of
-  Python 3.5 test coverage.
+* [Testing] Include Python 3.9 in the test matrix, remove remnants of Python 3.5 test coverage.
 
 Version 5.0.15 (2021-06-11)
 -------------------------
-* [Bug fix] Truncate the error message for `LaunchError` to fit
-  256 characters and thus, could be added to the `error_msg` field
-  of a `Stack`.
+
+* [Bug fix] Truncate the error message for `LaunchError` to fit 256 characters and thus, could be added to the `error_msg` field of a `Stack`.
 
 Version 5.0.14 (2021-06-02)
 -------------------------
-* [Bug fix] Make XBlock exports (from Studio or its REST API)
-  deterministic and predictable.
+
+* [Bug fix] Make XBlock exports (from Studio or its REST API) deterministic and predictable.
 * [Enhancement] Add tests for the new export/import logic.
 * [Bug fix] Restrict stack names to ASCII characters and digits.
 
 Version 5.0.13 (2021-05-21)
 -------------------------
+
 * [Bug fix] Fix RDP connectivity check for IPv6 stacks.
 
 Version 5.0.12 (2021-05-12)
 -------------------------
-* [Enhancement] Speed up progress checks by reducing the sleep time when
-  waiting for a remote execution of a command to finish.
+
+* [Enhancement] Speed up progress checks by reducing the sleep time when waiting for a remote execution of a command to finish.
 
 Version 5.0.11 (2021-05-10)
 -------------------------
-* [Bug fix] Add constraints to `dogpile.cache` and `cliff`, so that our
-  OpenStack client libraries will not have dependency conflicts.
+
+* [Bug fix] Add constraints to `dogpile.cache` and `cliff`, so that our OpenStack client libraries will not have dependency conflicts.
 
 Version 5.0.10 (2021-04-26)
 -------------------------
-* [Enhancement] Relax version constraints in `requirements/base.txt`
-  so that the OpenStack Train release becomes our reference point for
-  OpenStack client libraries. Simultaneously, relax the version
-  constraints for Paramiko and Tenacity.
+
+* [Enhancement] Relax version constraints in `requirements/base.txt` so that the OpenStack Train release becomes our reference point for OpenStack client libraries.
+  Simultaneously, relax the version constraints for Paramiko and Tenacity.
 
 Version 5.0.9 (2021-04-22)
 -------------------------
-* [Enhancement] Display the "check progress" button (if enabled) in
-  blue, to provide greater contrast to the red reset button.
-* [Enhancement] Make the warning learners see when they reset a lab
-  more verbose. Also, add a specific warning in case the XBlock is
-  being displayed in a timed exam, indicating that the exam timer will
-  continue to run while the lab is being reset.
+
+* [Enhancement] Display the "check progress" button (if enabled) in blue, to provide greater contrast to the red reset button.
+* [Enhancement] Make the warning learners see when they reset a lab more verbose.
+  Also, add a specific warning in case the XBlock is being displayed in a timed exam, indicating that the exam timer will continue to run while the lab is being reset.
 
 Version 5.0.8 (2021-04-21)
 -------------------------
-* [Bug fix] Revert previous unsuccessful attempt to refactor Celery
- logic.
-* [Bug fix] Use the "old" Celery Task base class, which our tasks
-  were originally built on.
+
+* [Bug fix] Revert previous unsuccessful attempt to refactor Celery logic.
+* [Bug fix] Use the "old" Celery Task base class, which our tasks were originally built on.
 
 Version 5.0.7 (2021-04-16)
 -------------------------
-**Do not use this release.** This contains a change breaking Celery
-task invocation, and was never published on PyPI.
 
-* [Bug fix] Refactor Celery tasks logic to define a Celery app
-  and register our class based tasks to that app.
+**Do not use this release.** This contains a change breaking Celery task invocation, and was never published on PyPI.
+
+* [Bug fix] Refactor Celery tasks logic to define a Celery app and register our class based tasks to that app.
 
 Version 5.0.6 (2021-04-07)
 --------------------------
+
 * [Bug fix] Refactor closing ssh connection in `finally` blocks.
 
 Version 5.0.5 (2021-03-30)
 --------------------------
-* [Bug fix] Add `null=True` for `key` and `password` in the Stack
-  model. The fix in 5.0.4 does not lead to the desired schema update
-  on MariaDB 10.2 (it does not change the schema at all), so rather
-  than using a default, allow NULL values instead.
+
+* [Bug fix] Add `null=True` for `key` and `password` in the Stack model.
+  The fix in 5.0.4 does not lead to the desired schema update on MariaDB 10.2 (it does not change the schema at all), so rather than using a default, allow NULL values instead.
 
 Version 5.0.4 (2021-03-26)
 --------------------------
-* [Enhancement] Use full names for common.djangoapps imports from
-  edx-platform.
+
+* [Enhancement] Use full names for common.djangoapps imports from edx-platform.
 * [Enhancement] Update requirements for Open EdX Koa release.
 * [Bug fix] Fix two missing defaults in the Stack model.
 
 Version 5.0.3 (2021-03-22)
 ---------------------------
-* [Bug fix] Update test dependencies to address
-  [CVE-2021-3281](https://nvd.nist.gov/vuln/detail/CVE-2021-3281).
-* [Enhancement] Add logging to provider actions, to make interactions
-  with cloud platforms more easily traceable.
+
+* [Bug fix] Update test dependencies to address [CVE-2021-3281](https://nvd.nist.gov/vuln/detail/CVE-2021-3281).
+* [Enhancement] Add logging to provider actions, to make interactions with cloud platforms more easily traceable.
 
 Version 5.0.2 (2021-03-17)
 ---------------------------
-* [Bug fix] Make Paramiko SSH connections more robust against socket
-  timeouts (and retry the connection if it runs into one).
+
+* [Bug fix] Make Paramiko SSH connections more robust against socket timeouts (and retry the connection if it runs into one).
 
 Version 5.0.1 (2021-03-04)
 ---------------------------
-* [DEPRECATION] As of this release, the previous implementation that
-  relied on the Guacamole Tomcat servlet is deprecated. A `stable-4.1`
-  branch exists that might still receive bugfixes for some time, but
-  do not count on this being supported any longer than the lifetime of
-  the Open edX Koa release. The [Ansible
-  playbooks](https://github.com/hastexo/edx-configuration/tree/hastexo/juniper/hastexo_xblock)
-  that tie into `edx-configuration` have been updated to “do the right
-  thing” based on the hastexo XBlock version being deployed: for
-  version 5 and up, they deploy Daphne and pyguacamole; for earlier
-  versions, they continue to deploy Tomcat and the Guacamole servlet.
+
+* [DEPRECATION] As of this release, the previous implementation that relied on the Guacamole Tomcat servlet is deprecated.
+  A `stable-4.1` branch exists that might still receive bugfixes for some time, but do not count on this being supported any longer than the lifetime of the Open edX Koa release.
+  The [Ansible playbooks](https://github.com/hastexo/edx-configuration/tree/hastexo/juniper/hastexo_xblock) that tie into `edx-configuration` have been updated to "do the right thing" based on the hastexo XBlock version being deployed: for version 5 and up, they deploy Daphne and pyguacamole; for earlier versions, they continue to deploy Tomcat and the Guacamole servlet.
 
 Version 5.0.0rc6 (2021-03-01)
 ---------------------------
+
 * [Bug fix] Add a default `port` value for `rdp` connections.
 
 Version 5.0.0rc5 (2021-02-23)
@@ -425,149 +386,117 @@ Version 5.0.0rc5 (2021-02-23)
 
 Version 5.0.0rc3 (2021-02-22)
 ----------------------------
-* [Bug fix] Fix `read_only` mode `key` and `mouse` event filtering
-  logic.
+
+* [Bug fix] Fix `read_only` mode `key` and `mouse` event filtering logic.
 
 Version 5.0.0rc2 (2021-02-19)
 -----------------------------
-* [Enhancement] Implement the `read_only` mode in the websocket
-  consumer by not passing any `key` or `mouse` events to `guacamole`
-  when set to `True`.
-* [Bug fix] Include `stack_protocol` attribute when initializing the
-  javascript code so that the terminal height value will be calculated
-  correctly.
-* [Bug fix] Refactor asyncio task creation logic to also work with
-  python3.5.
+
+* [Enhancement] Implement the `read_only` mode in the websocket consumer by not passing any `key` or `mouse` events to `guacamole` when set to `True`.
+* [Bug fix] Include `stack_protocol` attribute when initializing the javascript code so that the terminal height value will be calculated correctly.
+* [Bug fix] Refactor asyncio task creation logic to also work with python3.5.
 * [Bug fix] Add missing dependencies for `hastexo_guacamole_client`.
 
 Version 5.0.0rc1 (2021-02-16)
 -----------------------------
-* [Enhancement] Allow overriding settings for the
-  `hastexo_guacamole_client` from a configuration file by defining
-  it as `HASTEXO_GUACAMOLE_CFG`.
+
+* [Enhancement] Allow overriding settings for the `hastexo_guacamole_client` from a configuration file by defining it as `HASTEXO_GUACAMOLE_CFG`.
 
 Version 5.0.0rc0 (2021-02-02)
 -----------------------------
-* [BREAKING CHANGE] Replace Guacamole servlet with a Django ASGI
-  application, which uses Django-Channels and the
-  [pyguacamole](https://pypi.org/project/pyguacamole/) library.  
-  As of 5.0, deployment of this XBlock will no longer rely on the
-  Apache Tomcat servlet container, which Guacamole normally uses, but
-  instead on the Daphne ASGI server. If you have been deploying this
-  XBlock with the modified edx-configuration playbooks as explained in
-  the README, deployment should still be automatic for you. It is,
-  however, strongly advised that you respin your app servers from
-  scratch, in order to keep any residual Tomcat servlet configuration
-  from lingering on them.
+
+* [BREAKING CHANGE] Replace Guacamole servlet with a Django ASGI application, which uses Django-Channels and the [pyguacamole](https://pypi.org/project/pyguacamole/) library.
+  As of 5.0, deployment of this XBlock will no longer rely on the Apache Tomcat servlet container, which Guacamole normally uses, but instead on the Daphne ASGI server.
+  If you have been deploying this XBlock with the modified edx-configuration playbooks as explained in the README, deployment should still be automatic for you.
+  It is, however, strongly advised that you respin your app servers from scratch, in order to keep any residual Tomcat servlet configuration from lingering on them.
 
 Version 4.1.11 (2021-02-23)
 -------------------------
-* [Bug fix] When deleting learner state, the `stack_name` value
-  gets wiped out. If we then try to update the stack (for example
-  via `keepalive`) we get `Stack.DoesNotExist` error. Check if
-  `stack_name` has a value before attempting to update and if not,
-  set it again.
+
+* [Bug fix] When deleting learner state, the `stack_name` value gets wiped out.
+  If we then try to update the stack (for example via `keepalive`) we get `Stack.DoesNotExist` error.
+  Check if `stack_name` has a value before attempting to update and if not, set it again.
 
 Version 4.1.10 (2021-02-11)
 -------------------------
-* [Bug fix] Implement more of `ScorableXBlockMixin` functionality
-  for using the grading related instructor tasks like overriding
-  and rescoring learner's submissions.
+
+* [Bug fix] Implement more of `ScorableXBlockMixin` functionality for using the grading related instructor tasks like overriding and rescoring learner's submissions.
 
 Version 4.1.9 (2021-02-10)
 -------------------------
-* [Bug fix] Make the XBlock a subclass of `ScorableXBlockMixin` so
-  grades would be calculated correctly for each subsection.
-* [Enhancement] Make progress check wait dialog wording more general
-  and more suitable for different progress check configurations.
+
+* [Bug fix] Make the XBlock a subclass of `ScorableXBlockMixin` so grades would be calculated correctly for each subsection.
+* [Enhancement] Make progress check wait dialog wording more general and more suitable for different progress check configurations.
 
 Version 4.1.8 (2021-02-02)
 -------------------------
-[Bug fix] Fix export error, when provider attributes are not defined.
+
+* [Bug fix] Fix export error, when provider attributes are not defined.
 
 Version 4.1.7 (2021-01-29)
 -------------------------
-[Enhancement] Make the progress check result header configurable
- and allow to enable/disable showing feedback for task completion.
+
+* [Enhancement] Make the progress check result header configurable and allow to enable/disable showing feedback for task completion.
 
 Version 4.1.6 (2021-01-26)
 -------------------------
-[Enhancement] Allow to enable/disable displaying test stderr
-  output streams as hints.
-[Enhancement] Make the progress check button label configurable.
+
+* [Enhancement] Allow to enable/disable displaying test stderr output streams as hints.
+* [Enhancement] Make the progress check button label configurable.
 
 Version 4.1.5 (2021-01-25)
 --------------------------
+
 * [Bug fix] Fix ICMP connectivity check for IPv6-only stacks.
 
 Version 4.1.4 (2021-01-14)
 --------------------------
-* [Enhancement] Run integration tests in GitHub Actions, rather than
-  Travis CI.
-* [Bug fix] Only add `template` and `environment` attributes
-  to a provider during course export and import when they have a value.
+
+* [Enhancement] Run integration tests in GitHub Actions, rather than Travis CI.
+* [Bug fix] Only add `template` and `environment` attributes to a provider during course export and import when they have a value.
   Adding a `null` or `None` values can cause breakage with spinning up labs.
 * [Enhancement] Update test requirements.
 
 Version 4.1.3 (2020-12-11)
 ---------------------------
 
-* [Enhancement] Add a `read_only` XBlock attribute which, when set,
-  blocks all keyboard and mouse interaction with the Guacamole
-  terminal (effectively rendering it read-only). Defaults to `false`,
-  meaning the terminal is rendered with full interactivity by default.
+* [Enhancement] Add a `read_only` XBlock attribute which, when set, blocks all keyboard and mouse interaction with the Guacamole terminal (effectively rendering it read-only).
+  Defaults to `false`, meaning the terminal is rendered with full interactivity by default.
 
 Version 4.1.2 (2020-12-03)
 ---------------------------
 
-* [Bug fix] The XBlock allows to configure the layout for lab
-  instructions to be either above, below, left or right from the
-  terminal.  However, that configuration was not working properly for
-  lab instructions that are in a nested block.
+* [Bug fix] The XBlock allows to configure the layout for lab instructions to be either above, below, left or right from the terminal.
+  However, that configuration was not working properly for lab instructions that are in a nested block.
 
 Version 4.1.1 (2020-11-23)
 ---------------------------
 
-* [Bug fix] Correct the erroneous Maven `pom.xml` that accidentally
-  bumped 4.0.0 references to 4.1.0 in the prior release. It should
-  obviously have only bumped the package's own `<version>` string, and
-  not the model version, schema, or namespace reference.
+* [Bug fix] Correct the erroneous Maven `pom.xml` that accidentally bumped 4.0.0 references to 4.1.0 in the prior release.
+  It should obviously have only bumped the package's own `<version>` string, and not the model version, schema, or namespace reference.
 
 Version 4.1.0 (2020-11-23)
 ---------------------------
 
-**Do not use this release.** An erroneous invocation of `bumpversion`
-resulted in a Maven `pom.xml` that renders the Guacamole subsystem
-`.war` file impossible to build.
+**Do not use this release.** An erroneous invocation of `bumpversion` resulted in a Maven `pom.xml` that renders the Guacamole subsystem `.war` file impossible to build.
 
-* [Enhancement] Refactor course export/import logic. XBlock editable
-  fields are added as attributes to the <hastexo> element in a
-  vertical block.  `hook_events`, `ports`, `providers` and `tests` are
-  exported to a separate xml file. This does not affect existing
-  deployed courses using the XBlock, but might possibly require some
-  tweaking to automated deployment pipelines that rely on import and
-  export.
+* [Enhancement] Refactor course export/import logic.
+  XBlock editable fields are added as attributes to the <hastexo> element in a vertical block.
+  `hook_events`, `ports`, `providers` and `tests` are exported to a separate xml file.
+  This does not affect existing deployed courses using the XBlock, but might possibly require some tweaking to automated deployment pipelines that rely on import and export.
 * [Bug fix] Fix support for nested `<video>` elements.
-* [Enhancement] Support `<markdown>` (from the
-  [markdown-xblock](https://pypi.org/project/markdown-xblock/)
-  package) as an additional nested element (in addition to `<html>`,
-  `<pdf>`, and `<video>`).
+* [Enhancement] Support `<markdown>` (from the [markdown-xblock](https://pypi.org/project/markdown-xblock/) package) as an additional nested element (in addition to `<html>`, `<pdf>`, and `<video>`).
 
 Version 4.0.0 (2020-11-10)
 ---------------------------
 
 * [Enhancement] Enable overriding 'delete_age' via XBlock attribute in seconds.
-  The global settings still only accepts 'delete_age' value in days but
-  is now converted to seconds internally. In future releases the settings will
-  begin to support suffixes 'd', 'h', 'm' and 's'.
-* [BACKWARD INCOMPATIBLE] This release removes Python 2.7 from the
-  test matrix. This in turn means that we have also removed XBlock 1.1
-  and XBlock 1.2 from the test matrix (both of which rely on Python
-  2).
+  The global settings still only accepts 'delete_age' value in days but is now converted to seconds internally.
+  In future releases the settings will begin to support suffixes 'd', 'h', 'm' and 's'.
+* [BACKWARD INCOMPATIBLE] This release removes Python 2.7 from the test matrix.
+  This in turn means that we have also removed XBlock 1.1 and XBlock 1.2 from the test matrix (both of which rely on Python 2).
 * [Testing] Include XBlock 1.4 in the test matrix.
-* [Testing] Include a .gitlab-ci.yml file for running CI tests
-  when mirroring this repository onto a public or private GitLab
-  instance.
+* [Testing] Include a .gitlab-ci.yml file for running CI tests when mirroring this Repository onto a public or private GitLab instance.
 
 Version 3.6.10 (2020-10-21)
 ---------------------------
@@ -597,10 +526,8 @@ Version 3.6.6 (2020-08-03)
 Version 3.6.5 (2020-07-16)
 ---------------------------
 
-* [Bug fix] Correctly include the "reaper" and "suspender" manage.py
-  commands in packaging.
+* [Bug fix] Correctly include the "reaper" and "suspender" manage.py commands in packaging.
 * [Testing] Include unit tests for the manage.py commands.
-
 
 Version 3.6.4 (2020-07-16)
 ---------------------------
@@ -613,8 +540,8 @@ Version 3.6.4 (2020-07-16)
 Version 3.6.3 (2020-05-20)
 ---------------------------
 
-This is the last release to be tested against Python 2.7.
-Any subsequent releases will support Python 3 only.
+* This is the last release to be tested against Python 2.7.
+  Any subsequent releases will support Python 3 only.
 
 * [Enhancement] Support XBlock 1.3 (Python 3 only)
 * [Enhancement] Refactor database error retries, using tenacity
@@ -624,16 +551,13 @@ Version 3.6.2 (2020-05-05)
 ---------------------------
 
 * [Bug fix] Retry database query to fetch per-provider stack count
-* [Documentation] Add documentation for maintainers (on how to cut a
-  release)
-* [Documentation] Include README.md in the package’s PyPI description
-
+* [Documentation] Add documentation for maintainers (on how to cut a release)
+* [Documentation] Include README.md in the package's PyPI description
 
 Version 3.6.1 (2020-04-15)
 ---------------------------
 
-* [Bug fix] Always, rather than selectively, retry failed database
-  updates from Celery tasks
+* [Bug fix] Always, rather than selectively, retry failed database updates from Celery tasks
 
 Version 3.6.0 (2020-03-30)
 ---------------------------
@@ -643,8 +567,7 @@ Version 3.6.0 (2020-03-30)
 Version 3.5.1 (2020-03-25)
 ---------------------------
 
-* [Bug fix] Include suspended stacks in count to assess provider
-  capacity and utilization
+* [Bug fix] Include suspended stacks in count to assess provider capacity and utilization
 
 Version 3.5.0 (2020-03-19)
 ---------------------------
@@ -692,11 +615,8 @@ Version 3.2.0 (2019-08-13)
 * [Enhancement] tasks.py: continue on specific EnvironmentErrors during SSH connection
 * [Enhancement] Update devstack documentation
 * [Enhancement] Task hooks
-* [DEPRECATION] `reboot_on_resume` will be removed in a future release, as its
-  intended purpose is now better served by task hooks.
-* [CONFIGURATION] The `suspend_in_parallel` configuration option is now a NOOP,
-  as suspension now always happens in parallel via simultaneously running
-  Celery tasks.
+* [DEPRECATION] `reboot_on_resume` will be removed in a future release, as its intended purpose is now better served by task hooks.
+* [CONFIGURATION] The `suspend_in_parallel` configuration option is now a NOOP, as suspension now always happens in parallel via simultaneously running Celery tasks.
 
 Version 3.1.1 (2019-08-02)
 ---------------------------

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,50 +1,33 @@
 Developer notes
 ===============
 
-This document is for people who maintain and contribute to this
-repository.
-
+This document is for people who maintain and contribute to this repository.
 
 How to run tests
 ----------------
 
-This repo uses [tox](https://tox.readthedocs.io/) for unit and
-integration tests. It does not install `tox` for you, you should
-follow [the installation
-instructions](https://tox.readthedocs.io/en/latest/install.html) if
-your local setup does not yet include `tox`.
+This repo uses [tox](https://tox.readthedocs.io/) for unit and integration tests.
+It does not install `tox` for you, you should follow [the installation instructions](https://tox.readthedocs.io/en/latest/install.html) if your local setup does not yet include `tox`.
 
-You are encouraged to set up your checkout such
-that the tests run on every commit, and on every push. To do so, run
-the following command after checking out this repository:
+You are encouraged to set up your checkout such that the tests run on every commit, and on every push.
+To do so, run the following command after checking out this repository:
 
 ```bash
 git config core.hooksPath .githooks
 ```
 
-Once your checkout is configured in this manner, every commit will run
-a code style check (with [Flake8](https://flake8.pycqa.org/)), and
-every push to a remote topic branch will result in a full `tox` run.
+Once your checkout is configured in this manner, every commit will run a code style check (with [Flake8](https://flake8.pycqa.org/)), and every push to a remote topic branch will result in a full `tox` run.
 
-In addition, we use [GitHub
-Actions](https://docs.github.com/en/actions) to run the same checks
-on every push to GitHub.
+In addition, we use [GitHub Actions](https://docs.github.com/en/actions) to run the same checks on every push to GitHub.
 
-*If you absolutely must,* you can use the `--no-verify` flag to `git
-commit` and `git push` to bypass local checks, and rely on GitHub
-Actions alone. But doing so is strongly discouraged.
-
+*If you absolutely must,* you can use the `--no-verify` flag to `git commit` and `git push` to bypass local checks, and rely on GitHub Actions alone. But doing so is strongly discouraged.
 
 How to cut a release
 --------------------
 
-This repository uses
-[bump2version](https://pypi.org/project/bump2version/) (the maintained
-fork of [bumpversion](https://github.com/peritus/bumpversion)) for
-managing new releases.
+This repository uses [bump2version](https://pypi.org/project/bump2version/) (the maintained fork of [bumpversion](https://github.com/peritus/bumpversion)) for managing new releases.
 
-Before cutting a new release, open `Changelog.md` and add a new
-section like this:
+Before cutting a new release, open `Changelog.md` and add a new section like this:
 
 ```markdown
 Unreleased
@@ -62,16 +45,11 @@ Then, use `tox -e bumpversion` to increase the version number:
 -   `tox -e bumpversion minor`: creates a new minor release, with the patch level set to 0 (such as 3.7.0)
 -   `tox -e bumpversion major`: creates a new major release, with the minor and patch levels set to 0 (such as 4.0.0)
 
-This creates a new commit, and also a new tag, named `v<num>`, where
-`<num>` is the new version number.
+This creates a new commit, and also a new tag, named `v<num>`, where `<num>` is the new version number.
 
-Push these two commits (the one for the changelog, and the version
-bump) to `origin`. Make sure you push the `v<num>` tag to `origin` as
-well.
+Push these two commits (the one for the changelog, and the version bump) to `origin`. Make sure you push the `v<num>` tag to `origin` as well.
 
-Then, build a new `sdist` package (with [build](https://pypi.org/project/build/)), and [upload it to
-PyPI](https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives)
-(with [twine](https://packaging.python.org/key_projects/#twine)):
+Then, build a new `sdist` package (with [build](https://pypi.org/project/build/)), and [upload it to PyPI](https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives) (with [twine](https://packaging.python.org/key_projects/#twine)):
 
 ```bash
 rm dist/* -f
@@ -82,17 +60,14 @@ twine upload dist/*
 How to add support for new Apache Guacamole versions
 ----------------------------------------------------
 
-Download the minified `guacamole-common-js` file from [maven](https://repo1.maven.org/maven2/org/apache/guacamole/guacamole-common-js/)
-and add it to the `/hastexo/public/js/guacamole-common-js/` directory, prepending the version number
-to the `all.min.js` file name, separated by a hyphen ("-").
+Download the minified `guacamole-common-js` file from [maven](https://repo1.maven.org/maven2/org/apache/guacamole/guacamole-common-js/) and add it to the `/hastexo/public/js/guacamole-common-js/` directory, prepending the version number to the `all.min.js` file name, separated by a hyphen ("-").
 
 The desired guacamole version can then be selected via the `guacamole_js_version` setting.
 
 How to add translations
 -----------------------
 
-Install the [openedx i18n tools](https://github.com/openedx/i18n-tools) to your venv:
-`pip install edx-i18n-tools`
+Install the [openedx i18n tools](https://github.com/openedx/i18n-tools) to your venv: `pip install edx-i18n-tools`
 
 Add translations for a new language:
  * Create the directories for the new language to the `/locale/` directory following the pattern: `<lang>/LC_MESSAGES`, where `<lang>` is one of the locales listed in `hastexo/locale/config.yaml`.

--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ It is only limited by the feature set of the cloud's deployment features.
 Running this XBlock with Tutor (for Open edX Maple and later) requires two steps:
 
 1. Install the XBlock to your Tutor environment by adding it to the `OPENEDX_EXTRA_PIP_REQUIREMENTS` list in `config.yml`:
-   ```
+   ```yaml
    OPENEDX_EXTRA_PIP_REQUIREMENTS:
      - "hastexo-xblock==8.7.0"
    ```
    For additional information, please refer to the [official documentation](https://docs.tutor.overhang.io/configuration.html#installing-extra-xblocks-and-requirements).
 
 2. Install and enable the `tutor-contrib-hastexo` plugin:
-   ```
+   ```shell
    pip install git+https://github.com/cleura/tutor-contrib-hastexo
    tutor plugins enable hastexo
    ```
    Add the necessary configurations to your Tutor `config.yml`.
    Unless you want to change the default configurations, you'll only need to add the settings for the XBlock via `HASTEXO_XBLOCK_SETTINGS`, for example:
-   ```
+   ```yaml
    HASTEXO_XBLOCK_SETTINGS:
      check_timeout: 120
      delete_age: 0
@@ -121,13 +121,13 @@ Running this XBlock with Tutor (for Open edX Maple and later) requires two steps
    For more details about each setting, please refer to [the *XBlock settings* section](#xblock-settings) below.
 
 3. Before deploying services with Tutor, build the Docker image for the `hastexo` service, and also build a custom `openedx` image:
-   ```
+   ```shell
    tutor images build openedx hastexo
    ```
    For more information about the plugin configuration, please refer to [the plugin README](https://github.com/cleura/tutor-contrib-hastexo).
 
 4. After you have deployed Open edX with Tutor, your platform is operational, and you have created a course in Open edX Studio, go to *Settings* → *Advanced Settings* and add the `hastexo` module to *Advanced Module List,* like so:
-   ```
+   ```json
    [
     "annotatable",
     "openassessment",
@@ -307,7 +307,7 @@ A sample Heat template is provided under `samples/hot/sample-template.yaml`.
 
 Accepting the run parameter:
 
-```
+```yaml
 run:
   type: string
   description: Stack run
@@ -315,7 +315,7 @@ run:
 
 Generating an SSH key pair:
 
-```
+```yaml
 training_key:
   type: OS::Nova::KeyPair
   properties:
@@ -325,7 +325,7 @@ training_key:
 
 Generating a random password and setting it:
 
-```
+```yaml
 stack_password:
   type: OS::Heat::RandomString
   properties:
@@ -345,7 +345,7 @@ cloud_config:
 
 Defining the outputs:
 
-```
+```yaml
 outputs:
   public_ip:
     description: Floating IP address of deploy in public network
@@ -442,7 +442,7 @@ You can also use the following nested XML options:
 
 For example, in XML:
 
-```
+```xml
 <vertical url_name="lab_introduction">
   <hastexo xmlns:option="http://code.edx.org/xblock/option"
     url_name="lab_introduction"
@@ -517,7 +517,7 @@ The following child block types are currently supported:
 
 If using OLX, html blocks can be defined separately in the `html` subdirectory as usual, with the child element referring to it by URL name:
 
-```
+```xml
 <vertical url_name="lab_introduction">
   <hastexo ...>
     <html url_name="lab_instructions">

--- a/README.md
+++ b/README.md
@@ -3,25 +3,17 @@
 
 # hastexo XBlock
 
-The hastexo [XBlock](https://xblock.readthedocs.org/en/latest/) is an
-[Open edX](https://open.edx.org/) API that integrates realistic lab
-environments into distributed computing courses. The hastexo XBlock
-allows students to access an OpenStack environment
-within an edX course.
+The hastexo [XBlock](https://xblock.readthedocs.org/en/latest/) is an [Open edX](https://open.edx.org/) API that integrates realistic lab environments into distributed computing courses.
+The hastexo XBlock allows students to access an OpenStack environment within an edX course.
 
-It leverages [Apache Guacamole](https://guacamole.incubator.apache.org/) as a
-browser-based connection mechanism, which includes the ability to connect to
-graphical user environments (via VNC and RDP), in addition to terminals (via
-SSH).
+It leverages [Apache Guacamole](https://guacamole.incubator.apache.org/) as a browser-based connection mechanism, which includes the ability to connect to graphical user environments (via VNC and RDP), in addition to terminals (via SSH).
 
 This repository was previously hosted under the `hastexo` GitHub organization, and moved to `cleura` in December 2025 as part of a routine repository consolidation.
 
 ## Version compatibility matrix
 
-You must install a supported release of this XBlock to match the
-Open edX and [Tutor](https://docs.tutor.overhang.io/) version you are
-deploying. If you are installing this plugin from a branch in this Git
-repository, you must select the appropriate one:
+You must install a supported release of this XBlock to match the Open edX and [Tutor](https://docs.tutor.overhang.io/) version you are deploying.
+If you are installing this plugin from a branch in this Git repository, you must select the appropriate one:
 
 | Open edX release | Tutor version | XBlock version | XBlock branch |
 |------------------|---------------|----------------|---------------|
@@ -35,58 +27,41 @@ repository, you must select the appropriate one:
 | Teak             | `>=20.0, <21` | `>=8.5`        | `master`      |
 | Ulmo             | `>=21.0, <22` | `>=8.6`        | `master`      |
 
-Instructions for deploying this XBlock with Tutor can be found
-below, in the [Deployment with Tutor](#deployment-with-tutor)
-section.
+Instructions for deploying this XBlock with Tutor can be found below, in the [Deployment with Tutor](#deployment-with-tutor) section.
 
 ## Purpose
 
-The hastexo XBlock orchestrates a virtual environment (a "stack") that runs on
-a private or public cloud (currently [OpenStack](https://www.openstack.org)) 
-using its orchestration engine. It provides a Secure Shell session directly 
-within the courseware.
+The hastexo XBlock orchestrates a virtual environment (a "stack") that runs on a private or public cloud (currently [OpenStack](https://www.openstack.org)) using its orchestration engine.
+It provides a Secure Shell session directly within the courseware.
 
-Stack creation is idempotent, so a fresh stack will be spun up only if it does
-not already exist. An idle stack will auto-suspend after a configurable time
-period, which is two minutes by default. The stack will resume automatically
-when the student returns to the lab environment.
+Stack creation is idempotent, so a fresh stack will be spun up only if it does not already exist.
+An idle stack will auto-suspend after a configurable time period, which is two minutes by default.
+The stack will resume automatically when the student returns to the lab environment.
 
-Since public cloud environments typically charge by the minute to *run*
-virtual machines, the hastexo XBlock makes lab environments cost effective to
-deploy. The hastexo XBlock can run a fully distributed virtual lab environment
-for a course in [Ceph](http://ceph.com), OpenStack, or
-[Open vSwitch](http://openvswitch.org/) for approximately $25 per
-month on a public cloud (assuming students use the environment for 1 hour per
-day).
+Since public cloud environments typically charge by the minute to *run* virtual machines, the hastexo XBlock makes lab environments cost effective to deploy.
+The hastexo XBlock can run a fully distributed virtual lab environment for a course in [Ceph](http://ceph.com), OpenStack, or [Open vSwitch](http://openvswitch.org/) for approximately $25 per month on a public cloud (assuming students use the environment for 1 hour per day).
 
-Course authors can fully define and customize the lab environment. It is only
-limited by the feature set of the cloud's deployment features.
-
+Course authors can fully define and customize the lab environment.
+It is only limited by the feature set of the cloud's deployment features.
 
 ## Deployment with [Tutor](https://docs.tutor.overhang.io)
 
-Running this XBlock with Tutor (for Open edX Maple and later) requires
-two steps:
+Running this XBlock with Tutor (for Open edX Maple and later) requires two steps:
 
-1. Install the XBlock to your Tutor environment by adding it to the
-   `OPENEDX_EXTRA_PIP_REQUIREMENTS` list in `config.yml`:
+1. Install the XBlock to your Tutor environment by adding it to the `OPENEDX_EXTRA_PIP_REQUIREMENTS` list in `config.yml`:
    ```
    OPENEDX_EXTRA_PIP_REQUIREMENTS:
      - "hastexo-xblock==8.7.0"
    ```
-   For additional information, please refer to the [official
-   documentation](https://docs.tutor.overhang.io/configuration.html#installing-extra-xblocks-and-requirements).
-
+   For additional information, please refer to the [official documentation](https://docs.tutor.overhang.io/configuration.html#installing-extra-xblocks-and-requirements).
 
 2. Install and enable the `tutor-contrib-hastexo` plugin:
    ```
    pip install git+https://github.com/cleura/tutor-contrib-hastexo
    tutor plugins enable hastexo
    ```
-   Add the necessary configurations to your Tutor `config.yml`. Unless
-   you want to change the default configurations, you'll only need to
-   add the settings for the XBlock via `HASTEXO_XBLOCK_SETTINGS`, for
-   example:
+   Add the necessary configurations to your Tutor `config.yml`.
+   Unless you want to change the default configurations, you'll only need to add the settings for the XBlock via `HASTEXO_XBLOCK_SETTINGS`, for example:
    ```
    HASTEXO_XBLOCK_SETTINGS:
      check_timeout: 120
@@ -143,22 +118,15 @@ two steps:
      terminal_font_size: '10'
      terminal_url: /hastexo-xblock/
    ```
-   For more details about each setting, please refer to [the *XBlock
-   settings* section](#xblock-settings) below.
+   For more details about each setting, please refer to [the *XBlock settings* section](#xblock-settings) below.
 
-3. Before deploying services with Tutor, build the Docker image for
-   the `hastexo` service, and also build a custom `openedx` image:
+3. Before deploying services with Tutor, build the Docker image for the `hastexo` service, and also build a custom `openedx` image:
    ```
    tutor images build openedx hastexo
    ```
-   For more information about the plugin configuration, please refer
-   to [the plugin
-   README](https://github.com/cleura/tutor-contrib-hastexo).
+   For more information about the plugin configuration, please refer to [the plugin README](https://github.com/cleura/tutor-contrib-hastexo).
 
-4. After you have deployed Open edX with Tutor, your platform is
-   operational, and you have created a course in Open edX Studio, go
-   to *Settings* → *Advanced Settings* and add the `hastexo` module to
-   *Advanced Module List,* like so:
+4. After you have deployed Open edX with Tutor, your platform is operational, and you have created a course in Open edX Studio, go to *Settings* → *Advanced Settings* and add the `hastexo` module to *Advanced Module List,* like so:
    ```
    [
     "annotatable",
@@ -169,184 +137,169 @@ two steps:
 
 ## XBlock settings
 
-The hastexo XBlock must be configured via `XBLOCK_SETTINGS` in
-`lms.env.json` (or `lms.yml), under the `hastexo` key.  At the very
-minimum, you must configure a single "default" provider with the
-credentials specific to the cloud you will be using.  All other
-variables can be left at their defaults.
+The hastexo XBlock must be configured via `XBLOCK_SETTINGS` in `lms.env.json` (or `lms.yml), under the `hastexo` key.
+At the very minimum, you must configure a single "default" provider with the credentials specific to the cloud you will be using.
+All other variables can be left at their defaults.
 
 This is a brief explanation of each:
 
-* `terminal_url`: URL to the Guacamole web app.  If it is defined with a fully
-  qualified domain, it must include the protocol (`http://` or `https://`).  If
-  not, it is assumed to be an absolute path based on the current
-  `window.location`.  (It is possible to define it with a ":"-prefixed port,
-  such as ":8080/hastexo-xblock/", for use in devstacks). (Default:
-  `/hastexo-xblock/`)
+* `terminal_url`: URL to the Guacamole web app.
+  If it is defined with a fully qualified domain, it must include the protocol (`http://` or `https://`).
+  If not, it is assumed to be an absolute path based on the current `window.location`.
+  (It is possible to define it with a ":"-prefixed port, such as ":8080/hastexo-xblock/", for use in devstacks).
+  (Default: `/hastexo-xblock/`)
 
-* `terminal_color_scheme`: Color scheme for the terminal window. Suitable values
-  are described in [Guacamole Documentation](https://guacamole.apache.org/doc/gug/configuring-guacamole.html#ssh).
-  For example, `foreground:rgb:ff/ff/ff;background:rgb:00/00/00` and
-  `white-black` both represent white text on a black background.
+* `terminal_color_scheme`: Color scheme for the terminal window.
+  Suitable values are described in [Guacamole Documentation](https://guacamole.apache.org/doc/gug/configuring-guacamole.html#ssh).
+  For example, `foreground:rgb:ff/ff/ff;background:rgb:00/00/00` and `white-black` both represent white text on a black background.
   (Default: `white-black`)
 
-* `terminal_font_name`: The name of the font to use in terminal. A matching font
-  must be installed on the Guacamole server. (Default: `monospace`) 
+* `terminal_font_name`: The name of the font to use in terminal.
+  A matching font must be installed on the Guacamole server.
+  (Default: `monospace`)
 
 * `terminal_font_size`: The size of the font to use in terminal, in points.
   (Default: `10`)
 
-* `instructions_layout`: Configuration for instructions layout. It's possible
-  to set the position for instructions to be 'above', 'below', 'left' or 'right'
-  from the terminal window. (Default: `above`; this is currently an
-  experimental feature)
+* `instructions_layout`: Configuration for instructions layout.
+  It's possible to set the position for instructions to be 'above', 'below', 'left' or 'right' from the terminal window.
+  (Default: `above`; this is currently an experimental feature)
 
-* `enable_fullscreen`: An option to allow learners to launch a lab in fullsceen mode,
-  in a separate browser window. (Default: `false`)
+* `enable_fullscreen`: An option to allow learners to launch a lab in fullsceen mode, in a separate browser window.
+  (Default: `false`)
 
-* `lab_resize_method`: A [display setting](https://guacamole.apache.org/doc/1.5.5/gug/configuring-guacamole.html#rdp-display-settings) for RDP connections to update the RDP server
-  when the width and height of the client display changes. Possible values are:
+* `lab_resize_method`: A [display setting](https://guacamole.apache.org/doc/1.5.5/gug/configuring-guacamole.html#rdp-display-settings) for RDP connections to update the RDP server when the width and height of the client display changes.
+  Possible values are:
 
-  * `display-update` *Only supported with Windows RDP 8.1 or xrdp 0.10.1 (and higher)*. 
+  * `display-update` *Only supported with Windows RDP 8.1 or xrdp 0.10.1 (and higher)*.
     Uses the "Display Update" channel to request the server to change the display size.
 
-  * `reconnect` (the default) Automatically disconnects the RDP session when the client 
-    display size has changed, and reconnects with the new size.
+  * `reconnect` (the default) Automatically disconnects the RDP session when the client display size has changed, and reconnects with the new size.
 
-* `lab_usage_limit`: Allocate limited time per user for labs across the platform,
-  in seconds. (Default is `None`, meaning there is no time limit).
+* `lab_usage_limit`: Allocate limited time per user for labs across the platform, in seconds.
+  (Default is `None`, meaning there is no time limit).
 
-* `lab_usage_limit_breach_policy`: What to do when the learner's lab
-  limit has been exceeded.
+* `lab_usage_limit_breach_policy`: What to do when the learner's lab limit has been exceeded.
 
   * `None` (the default) means just write a message to the logs.
 
-  * `warn` will display a warning to the learner that the
-  limit has been reached, but does allow them to keep using the labs.
+  * `warn` will display a warning to the learner that the limit has been reached, but does allow them to keep using the labs.
 
   * `block` blocks the learner's access to the lab.
 
 * `launch_timeout`: How long to wait for a stack to be launched, in seconds.
   (Default: `900`)
 
-* `remote_exec_timeout`: How long to wait for a command to be executed remotely
-  over SSH, in seconds.  (Default: `300`)
+* `remote_exec_timeout`: How long to wait for a command to be executed remotely over SSH, in seconds.
+  (Default: `300`)
 
-* `suspend_timeout`: How long to wait before suspending a stack, after the last
-  keepalive was received from the browser, in seconds.  (Default: `120`)
+* `suspend_timeout`: How long to wait before suspending a stack, after the last keepalive was received from the browser, in seconds.
+  (Default: `120`)
 
-* `suspend_interval`: The period between suspend job launches. (Default: `60`)
+* `suspend_interval`: The period between suspend job launches.
+  (Default: `60`)
 
-* `suspend_concurrency`: How many stacks to suspend on each job run. (Default:
-  `4`)
+* `suspend_concurrency`: How many stacks to suspend on each job run.
+  (Default: `4`)
 
-* `suspend_task_timeout`: How long to wait for a stack to be suspended, in
-  seconds.  (Default: `900`)
+* `suspend_task_timeout`: How long to wait for a stack to be suspended, in seconds.
+  (Default: `900`)
 
 * `check_timeout`: How long to wait before a check progress task fails.
   (Default: `120`)
 
-* `delete_age`: Delete stacks that haven't been resumed in this many days.  Set
-  to 0 to disable. (Default: 14)
+* `delete_age`: Delete stacks that haven't been resumed in this many days.
+  Set to 0 to disable.
+  (Default: 14)
 
-* `delete_interval`: The period between reaper job launches. (Default:
-  `3600`)
+* `delete_interval`: The period between reaper job launches.
+  (Default: `3600`)
 
 * `delete_attempts`: How many times to insist on deletion after a failure.
   (Default: `3`)
 
-* `delete_task_timeout`: How long to wait for a stack to be deleted, in
-  seconds.  (Default: `900`)
+* `delete_task_timeout`: How long to wait for a stack to be deleted, in seconds.
+  (Default: `900`)
 
 * `js_timeouts`:
 
-    * `status`: In the browser, when launching a stack, how long to wait
-      between polling attempts until it is complete, in milliseconds (Default:
-      `15000`)
+  * `status`: In the browser, when launching a stack, how long to wait between polling attempts until it is complete, in milliseconds.
+    (Default: `15000`)
 
-    * `keepalive`: In the browser, after the stack is ready, how long to wait
-      between keepalives to the server, in milliseconds. (Default: `30000`)
+  * `keepalive`: In the browser, after the stack is ready, how long to wait between keepalives to the server, in milliseconds.
+    (Default: `30000`)
 
-    * `idle`: In the browser, how long to wait until the user is considered
-      idle, when no input is registered in the terminal, in milliseconds.
-      (Default: `3600000`)
+  * `idle`: In the browser, how long to wait until the user is considered idle, when no input is registered in the terminal, in milliseconds.
+    (Default: `3600000`)
 
-    * `check`: In the browser, after clicking "Check Progress", how long to
-      wait between polling attempts, in milliseconds. (Default: `5000`)
+  * `check`: In the browser, after clicking "Check Progress", how long to wait between polling attempts, in milliseconds.
+    (Default: `5000`)
 
-* `providers`: A dictionary of OpenStack providers that course authors can pick
-  from.  Each entry is itself a dictionary containing provider configuration
-  parameters.  You must configure at least one, named "default".  The following
-  is a list of supported parameters:
+* `providers`: A dictionary of OpenStack providers that course authors can pick from.
+  Each entry is itself a dictionary containing provider configuration parameters.
+  You must configure at least one, named "default".
+  The following is a list of supported parameters:
 
-    * `type`: The provider type.  Currently "openstack".  Defaults
-      to "openstack" if not provided, for backwards-compatibility.
+  * `type`: The provider type.
+    Currently "openstack".
+    Defaults to "openstack" if not provided, for backwards-compatibility.
 
-    The following apply to OpenStack only:
+  The following apply to OpenStack only:
 
-    * `os_auth_url`: OpenStack auth URL.
+  * `os_auth_url`: OpenStack auth URL.
 
-    * `os_auth_token`: OpenStack auth token.
+  * `os_auth_token`: OpenStack auth token.
 
-    * `os_username`: OpenStack user name.
+  * `os_username`: OpenStack user name.
 
-    * `os_password`: OpenStack password.
+  * `os_password`: OpenStack password.
 
-    * `os_user_id`: OpenStack user id.
+  * `os_user_id`: OpenStack user id.
 
-    * `os_user_domain_id`: OpenStack domain id.
+  * `os_user_domain_id`: OpenStack domain id.
 
-    * `os_user_domain_name`: OpenStack domain name.
+  * `os_user_domain_name`: OpenStack domain name.
 
-    * `os_project_id`: OpenStack project id.
+  * `os_project_id`: OpenStack project id.
 
-    * `os_project_name`: OpenStack project name.
+  * `os_project_name`: OpenStack project name.
 
-    * `os_project_domain_id`: OpenStack project domain id.
+  * `os_project_domain_id`: OpenStack project domain id.
 
-    * `os_project_domain_name`: OpenStack project domain name.
+  * `os_project_domain_name`: OpenStack project domain name.
 
-    * `os_region_name`: OpenStack region name.
-
+  * `os_region_name`: OpenStack region name.
 
 ## Creating an orchestration template for your course
 
-To use the hastexo XBlock, start by creating an orchestration template and
-uploading it to the content store.  The XBlock imposes some constraints on the
-template (detailed below), but you are otherwise free to customize your
-training environment as needed.
+To use the hastexo XBlock, start by creating an orchestration template and uploading it to the content store.
+The XBlock imposes some constraints on the template (detailed below), but you are otherwise free to customize your training environment as needed.
 
 To ensure your template has the required configuration:
 
-1. Configure the template to accept a "run" parameter, which will contain
-   information about the course run where the XBlock is instanced.  This is
-   intended to give course authors a way to, for example, tie this to a
-   specific virtual image when launching VMs.
+1. Configure the template to accept a "run" parameter, which will contain information about the course run where the XBlock is instanced.
+   This is intended to give course authors a way to, for example, tie this to a specific virtual image when launching VMs.
 
-2. If your orchestration engine allows it, configure the template to generate
-   an SSH key pair dynamically and save the private key.
+2. If your orchestration engine allows it, configure the template to generate an SSH key pair dynamically and save the private key.
 
-3. In addition, if using RDP or VNC you must generate a random password and
-   assign it to the stack user.
+3. In addition, if using RDP or VNC you must generate a random password and assign it to the stack user.
 
-4. Configure the template to have at least one instance that is publicly
-   accessible via an IPv4 address.
+4. Configure the template to have at least one instance that is publicly accessible via an IPv4 address.
 
 5. Provide the following outputs with these exact names:
 
-    * `public_ip`: The publically accessible instance.
+  * `public_ip`: The publically accessible instance.
 
-    * `private_key`: The generated passphrase-less SSH private key.
+  * `private_key`: The generated passphrase-less SSH private key.
 
-    * `password`: The generated password. (OPTIONAL)
+  * `password`: The generated password.
+    (OPTIONAL)
 
-    * `reboot_on_resume`: A list of servers to be rebooted upon resume.  This
-      is meant primarily as a workaround to resurrect servers that use nested
-      KVM, as the latter does not support a managed save and subsequent
-      restart. (OPTIONAL, DEPRECATED)
+  * `reboot_on_resume`: A list of servers to be rebooted upon resume.
+    This is meant primarily as a workaround to resurrect servers that use nested KVM, as the latter does not support a managed save and subsequent restart.
+    (OPTIONAL, DEPRECATED)
 
-6. Upload the template to the content store and make a note of its static asset
-   file name.
+6. Upload the template to the content store and make a note of its static asset file name.
 
 ### Heat examples
 
@@ -354,149 +307,138 @@ A sample Heat template is provided under `samples/hot/sample-template.yaml`.
 
 Accepting the run parameter:
 
-    ```
-    run:
-      type: string
-      description: Stack run
-    ```
+```
+run:
+  type: string
+  description: Stack run
+```
 
 Generating an SSH key pair:
 
-    ```
-    training_key:
-      type: OS::Nova::KeyPair
-      properties:
-        name: { get_param: 'OS::stack_name' }
-        save_private_key: true
-    ```
+```
+training_key:
+  type: OS::Nova::KeyPair
+  properties:
+    name: { get_param: 'OS::stack_name' }
+    save_private_key: true
+```
 
 Generating a random password and setting it:
 
-    ```
-    stack_password:
-      type: OS::Heat::RandomString
-      properties:
-        length: 32
+```
+stack_password:
+  type: OS::Heat::RandomString
+  properties:
+    length: 32
 
+cloud_config:
+  type: OS::Heat::CloudConfig
+  properties:
     cloud_config:
-      type: OS::Heat::CloudConfig
-      properties:
-        cloud_config:
-          chpasswd:
-            list:
-              str_replace:
-                template: "user:{password}"
-                params:
-                  "{password}": { get_resource: stack_password }
-    ```
+      chpasswd:
+        list:
+          str_replace:
+            template: "user:{password}"
+            params:
+              "{password}": { get_resource: stack_password }
+```
 
 Defining the outputs:
 
-    ```
-    outputs:
-      public_ip:
-        description: Floating IP address of deploy in public network
-        value: { get_attr: [ deploy_floating_ip, floating_ip_address ] }
-      private_key:
-        description: Training private key
-        value: { get_attr: [ training_key, private_key ] }
-      password:
-        description: Stack password
-        value: { get_resource: stack_password }
-      reboot_on_resume:
-        description: Servers to be rebooted after resume
-        value:
-          - { get_resource: server1 }
-          - { get_resource: server2 }
-    ```
+```
+outputs:
+  public_ip:
+    description: Floating IP address of deploy in public network
+    value: { get_attr: [ deploy_floating_ip, floating_ip_address ] }
+  private_key:
+    description: Training private key
+    value: { get_attr: [ training_key, private_key ] }
+  password:
+    description: Stack password
+    value: { get_resource: stack_password }
+  reboot_on_resume:
+    description: Servers to be rebooted after resume
+    value:
+      - { get_resource: server1 }
+      - { get_resource: server2 }
+```
 
 ## Using the hastexo XBlock in a course
 
-To create a stack for a student and display a terminal window where invoked,
-you need to define the `hastexo` tag in your course content.   It must be
-configured with the following attributes:
+To create a stack for a student and display a terminal window where invoked, you need to define the `hastexo` tag in your course content.
+It must be configured with the following attributes:
 
-* `stack_user_name`: The name of the user that the Xblock will use to connect
-  to the environment, as specified in the orchestration template.
+* `stack_user_name`: The name of the user that the Xblock will use to connect to the environment, as specified in the orchestration template.
 
 The following are optional:
 
-* `stack_protocol`: One of `ssh`, `rdp`, or `vnc`. This defines the
-  protocol that will be used to connect to the environment. The
-  default is `ssh`.
+* `stack_protocol`: One of `ssh`, `rdp`, or `vnc`.
+  This defines the protocol that will be used to connect to the environment.
+  The default is `ssh`.
 
-* `stack_template_path`: The static asset path to the orchestration template,
-  if not specified per provider below.
+* `stack_template_path`: The static asset path to the orchestration template, if not specified per provider below.
 
 * `stack_key_type`: An SSH key type for accessing the lab environment.
-  Options are `rsa`, `ed25519` and `""` (default). If a key type is chosen,
-  a key with the selected type will be generated for the lab environment.
+  Options are `rsa`, `ed25519` and `""` (default).
+  If a key type is chosen, a key with the selected type will be generated for the lab environment.
   If set to an empty string, the key handling should be done via the lab template.
 
 * `launch_timeout`: How long to wait for a stack to be launched, in seconds.
   If unset, the global timeout will be used.
 
-* `suspend_timeout`: Timeout for how long to wait before suspending a stack,
-  after the last keepalive was received from the browser, in seconds.
+* `suspend_timeout`: Timeout for how long to wait before suspending a stack, after the last keepalive was received from the browser, in seconds.
   Takes precedence over the globally defined timeout."
 
 * `delete_age`: Delete stacks that haven't been resumed in this many seconds.
-  Overrides the globally defined setting. The global setting currently only
-  supports days but will begin to support suffixes `d`, `h`, `m`, `s` in future
-  releases. Using this attribute will allow setting the `delete_age` value per
-  instance and configure it to have a shorter value.
+  Overrides the globally defined setting.
+  The global setting currently only supports days but will begin to support suffixes `d`, `h`, `m`, `s` in future releases.
+  Using this attribute will allow setting the `delete_age` value per instance and configure it to have a shorter value.
 
-* `read_only`: Display a lab terminal in a `read-only` mode. If set to `True`,
-  a lab stack will be created or resumed as usual, the student can see the lab
-  terminal but is not able to interact with it. Default is `False`.
+* `read_only`: Display a lab terminal in a `read-only` mode.
+  If set to `True`, a lab stack will be created or resumed as usual, the student can see the lab terminal but is not able to interact with it.
+  Default is `False`.
 
-* `hidden`: An option to hide the lab itself in the browser while spinning up
-  the lab environment in the background. Default is `False`.
+* `hidden`: An option to hide the lab itself in the browser while spinning up the lab environment in the background.
+  Default is `False`.
 
-* `enable_fullscreen`: An option to allow learners to launch a lab in fullsceen mode,
-  in a separate browser window. If used, overrides the globally defined setting.
-  Options are "true", "false" and "inherit". Default is "inherit" (to use global value).
+* `enable_fullscreen`: An option to allow learners to launch a lab in fullsceen mode, in a separate browser window.
+  If used, overrides the globally defined setting.
+  Options are "true", "false" and "inherit".
+  Default is "inherit" (to use global value).
 
 * `progress_check_label`: Set a label for the progress check button.
   For example: `Submit Answer` or `Check Progress` (Default).
 
-* `show_feedback`: On progress check, show feedback on how many tasks out of total 
-  are completed. Default is `True`.
+* `show_feedback`: On progress check, show feedback on how many tasks out of total are completed.
+  Default is `True`.
 
-* `show_hints_on_error`: On progress check failure, display the tests' standard
-  error streams as hints.
-  When `show_feedback` is set to `False`, hints will never be displayed and having
-  this set to `True` will have no effect. Default is `True`.
+* `show_hints_on_error`: On progress check failure, display the tests' standard error streams as hints.
+  When `show_feedback` is set to `False`, hints will never be displayed and having this set to `True` will have no effect.
+  Default is `True`.
 
 * `progress_check_result_heading`: Message to display on progress check result window.
-  This could be set to "Answer Submitted" for example, when choosing to not display
-  hints and feedback. Default is "Progress check result".
+  This could be set to "Answer Submitted" for example, when choosing to not display hints and feedback.
+  Default is "Progress check result".
 
 You can also use the following nested XML options:
 
 * `providers`: A list of references to providers configured in the platform.
-  Each `name` attribute must match one of the providers in the XBlock
-  configuration. `capacity` specifies how many environments should be launched
-  in that provider at maximum (where "-1" means keep launching environments
-  until encountering a launch failure, and "0" disables the provider).
-  `template` is the content store path to the orchestration template (if not
-  given, `stack_template_path` will be used).  `environment` specifies a
-  content store path to a Heat environment file. If no providers are specified, 
-  the platform default will be used.
+  Each `name` attribute must match one of the providers in the XBlock configuration.
+  `capacity` specifies how many environments should be launched in that provider at maximum (where "-1" means keep launching environments until encountering a launch failure, and "0" disables the provider).
+  `template` is the content store path to the orchestration template (if not given, `stack_template_path` will be used).
+  `environment` specifies a content store path to a Heat environment file.
+  If no providers are specified, the platform default will be used.
 
-* `ports`: A list of ports the user can manually choose to connect to.  This is
-  intended as a means of providing a way to connect directly to multiple VMs in
-  a lab environment, via port forwarding or proxying at the VM with the public
-  IP address.  Each `name` attribute will be visible to the user.  The `number`
-  attribute specifies the corresponding port.
+* `ports`: A list of ports the user can manually choose to connect to.
+  This is intended as a means of providing a way to connect directly to multiple VMs in a lab environment, via port forwarding or proxying at the VM with the public IP address.
+  Each `name` attribute will be visible to the user.
+  The `number` attribute specifies the corresponding port.
 
-* `tests`: A list of test scripts.  The contents of each element will be run
-  verbatim a a script in the user's lab environment, when they click the "Check
-  Progress" button.  As such, each script should define an interpreter via the
-  "shebang" convention.  If any scripts fail with a retval greater than 0, the
-  learner gets a partial score for this instance of the XBlock.  In this case,
-  the `stderr` of failed scripts will be displayed to the learner as a list of
-  hints on how to proceed.
+* `tests`: A list of test scripts.
+  The contents of each element will be run verbatim a a script in the user's lab environment, when they click the "Check Progress" button.
+  As such, each script should define an interpreter via the "shebang" convention.
+  If any scripts fail with a retval greater than 0, the learner gets a partial score for this instance of the XBlock.
+  In this case, the `stderr` of failed scripts will be displayed to the learner as a list of hints on how to proceed.
 
 For example, in XML:
 
@@ -548,37 +490,32 @@ For example, in XML:
 </vertical>
 ```
 
-**Important**: Do this only *once per section*. Defining it more than once
-per section is not supported.
+**Important**: Do this only *once per section*.
+Defining it more than once per section is not supported.
 
-Note on tests: as seen in the above example, it is recommended to wrap them all
-in `<![CDATA[..]]>` tags.  This avoids XML parsing errors when special
-characters are encountered, such as the `>&2` used to output to stderr in bash.
+Note on tests: as seen in the above example, it is recommended to wrap them all in `<![CDATA[..]]>` tags.
+This avoids XML parsing errors when special characters are encountered, such as the `>&2` used to output to stderr in bash.
 
-In order to add the hastexo Xblock through Studio, open the unit where you want
-it to go.  Add a new component, select `Advanced`, then select the `Lab`
-component.  This adds the XBlock.  Edit the Settings as explained above.
+In order to add the hastexo Xblock through Studio, open the unit where you want it to go.
+Add a new component, select `Advanced`, then select the `Lab` component.
+This adds the XBlock.
+Edit the Settings as explained above.
 
 ### Using the hastexo XBlock in a content library
 
 This XBlock is usable in [content libraries](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_components/libraries.html).
-It supports adding lab instructions as child blocks, so that when the block is
-randomized, the instructions are bundled together with it.
+It supports adding lab instructions as child blocks, so that when the block is randomized, the instructions are bundled together with it.
 
-To add the XBlock to the library via Studio, make sure it is configured as one
-of the `ADVANCED_PROBLEM_TYPES` in `cms.env.json`, then select it as such when
-adding content to your library.  (Note: as of Open edX Ironwood, the ability to
-do so requires running a [patched version](https://github.com/hastexo/edx-platform/tree/hastexo/ironwood/free_the_library)
-of `edx-platform`.)
+To add the XBlock to the library via Studio, make sure it is configured as one of the `ADVANCED_PROBLEM_TYPES` in `cms.env.json`, then select it as such when adding content to your library.
+(Note: as of Open edX Ironwood, the ability to do so requires running a [patched version](https://github.com/hastexo/edx-platform/tree/hastexo/ironwood/free_the_library) of `edx-platform`.)
 
 The following child block types are currently supported:
 
-    * html
-    * video
-    * [pdf](https://github.com/MarCnu/pdfXBlock)
+  * html
+  * video
+  * [pdf](https://github.com/MarCnu/pdfXBlock)
 
-If using OLX, html blocks can be defined separately in the `html` subdirectory
-as usual, with the child element referring to it by URL name:
+If using OLX, html blocks can be defined separately in the `html` subdirectory as usual, with the child element referring to it by URL name:
 
 ```
 <vertical url_name="lab_introduction">
@@ -592,7 +529,7 @@ Child blocks will always be rendered _above_ the terminal.
 
 ### Using the hastexo XBlock while masquerading as a specific learner
 
-Instructors can use the hastexo XBlock lab environments when masquerading as a specific learner by using the "View this course as:" option in the LMS staff header.
+Instructors can use the hastexo XBlock lab environments when masquerading as a specific learner by using the "View this course as:" option in the LMS staff header.
 
 The learner will not know when an instructor is using their lab, so we advise to be mindful of the changes you make while the learner is active at the same lab.
 
@@ -600,70 +537,50 @@ This feature should be considered experimental, and is subject to future change 
 
 ## Student experience
 
-When students navigate to a unit with a hastexo XBlock in it, a new Heat
-stack will be created (or resumed) for them. The Heat stack will be as defined
-in the uploaded Heat template. It is unique per student and per course run. If
-the same tag appears on a different course, or different run of the same
-course, the student will get a different stack.
+When students navigate to a unit with a hastexo XBlock in it, a new Heat stack will be created (or resumed) for them.
+The Heat stack will be as defined in the uploaded Heat template.
+It is unique per student and per course run.
+If the same tag appears on a different course, or different run of the same course, the student will get a different stack.
 
-The stack will suspend if the student does not navigate to the `hastexo` unit
-in that section within the default two minutes (configurable via settings, as
-explained above). When the student gets to the `hastexo` unit, the stack will
-be resumed and they will be connected automatically and securely. They will not
-need a username, password, or host prompts to their personal lab environment.
+The stack will suspend if the student does not navigate to the `hastexo` unit in that section within the default two minutes (configurable via settings, as explained above).
+When the student gets to the `hastexo` unit, the stack will be resumed and they will be connected automatically and securely.
+They will not need a username, password, or host prompts to their personal lab environment.
 This happens transparently in the browser.
 
-The student can work at their own pace in their environment. However, when
-a student closes the browser where the `hastexo` unit is displayed, or if they
-put their computer to sleep, a countdown is started. If the student does not
-reopen the environment within two minutes their stack will be suspended. When
-a student comes back to the lab environment to finish the exercise, their
-stack is resumed automatically.  They are connected to the same training
-environment they were working with before, in the *same state* they left it in.
+The student can work at their own pace in their environment.
+However, when a student closes the browser where the `hastexo` unit is displayed, or if they put their computer to sleep, a countdown is started.
+If the student does not reopen the environment within two minutes their stack will be suspended.
+When a student comes back to the lab environment to finish the exercise, their stack is resumed automatically.
+They are connected to the same training environment they were working with before, in the *same state* they left it in.
 (The process of suspension works just like in a home computer.)
 
 ### Copy & paste
 
-Within the text terminal, learners can use copy and paste by marking
-up text with the left mouse button, and then using right-click or
-middle-click to paste.
+Within the text terminal, learners can use copy and paste by marking up text with the left mouse button, and then using right-click or middle-click to paste.
 
-Within the graphical (RDP) terminal, so long as the terminal has focus
-(normally meaning that the learner has left-clicked into it once),
-learners can use any copy and paste facility that the desktop
-provides. This includes the `Ctrl‑C`/`Ctrl‑V` key combinations, and
-middle mouse clicks.
+Within the graphical (RDP) terminal, so long as the terminal has focus (normally meaning that the learner has left-clicked into it once), learners can use any copy and paste facility that the desktop provides.
+This includes the `Ctrl‑C`/`Ctrl‑V` key combinations, and middle mouse clicks.
 
-Copy & paste to and from the lab environment (i.e. from the terminal
-to the learner's browser, or vice versa) is also possible, though some
-considerations apply.
+Copy & paste to and from the lab environment (i.e. from the terminal to the learner's browser, or vice versa) is also possible, though some considerations apply.
 
-Pasting _into_ the lab environment requires two transitions, because
-we are dealing with two clipboards (one for the browser and one for
-the lab environment). Thus, the learner must
+Pasting _into_ the lab environment requires two transitions, because we are dealing with two clipboards (one for the browser and one for the lab environment).
+Thus, the learner must:
 
 1. Copy something into their clipboard on their client.
 2. Left-click into the terminal.
-3. Hit `Ctrl‑V`. (This is the first transition, which populates the
-   terminal's clipboard.)
-4. Right-click, middle-click, or type `Ctrl‑Shift‑V` in the
-   terminal. (This is the second transition, which pastes from the
-   terminal's clipboard.)
+3. Hit `Ctrl‑V`. (This is the first transition, which populates the terminal's clipboard.)
+4. Right-click, middle-click, or type `Ctrl‑Shift‑V` in the terminal. (This is the second transition, which pastes from the terminal's clipboard.)
 
-Copying _out_ from the lab environment is more direct, though at this
-time it works only on Mozilla Firefox (support in other browsers may
-follow). To copy from their terminal into their local clipboard, the
-learner must
+Copying _out_ from the lab environment is more direct, though at this time it works only on Mozilla Firefox (support in other browsers may follow).
+To copy from their terminal into their local clipboard, the learner must:
 
 1. Mark up some text in their terminal.
 2. Switch to another application window on their client.
 3. Hit `Ctrl‑V`.
 
-
 ## Django admin page
 
-To facilitate management of stack states without direct access to the database,
-a Django admin page is provided as a frontend for the `hastexo_stack` table.
+To facilitate management of stack states without direct access to the database, a Django admin page is provided as a frontend for the `hastexo_stack` table.
 To access it, go to the following as a superuser:
 
 https://lms.example.com/admin/hastexo/stack
@@ -672,27 +589,19 @@ The following features are currently implemented:
 
 * Searching: Search for a stack's name, course ID, status, and provider.
 
-* Filtering: On the filter tab to the right, it is possible to select from a
-  preset list of three filters: `course_id`, `status`, and `provider`.  The
-  preset values are generated on the fly from existing records.
+* Filtering: On the filter tab to the right, it is possible to select from a preset list of three filters: `course_id`, `status`, and `provider`.
+  The preset values are generated on the fly from existing records.
 
-* On-list editing: modify multiple stack's states or providers directly from
-  the main list.
+* On-list editing: modify multiple stack's states or providers directly from the main list.
 
-* Marking stacks as deleted in bulk: to quickly change multiple stack states to
-  `DELETE_COMPLETE`, and to reset their providers to "", select multiple stacks
-  and use the "Mark selected stacks as DELETE_COMPLETE" action from the action
-  dropdown.
+* Marking stacks as deleted in bulk: to quickly change multiple stack states to `DELETE_COMPLETE`, and to reset their providers to "", select multiple stacks and use the "Mark selected stacks as DELETE_COMPLETE" action from the action dropdown.
 
-* Displaying owner's email: when opening a stack's edit form (by clicking on
-  its name), the owner's email is displayed.
+* Displaying owner's email: when opening a stack's edit form (by clicking on its name), the owner's email is displayed.
 
-When changing providers, only the ones enabled by the author for the course in
-question are displayed.  If none are present, then the list is expanded with
-the full set of providers configured in the platform.
+When changing providers, only the ones enabled by the author for the course in question are displayed.
+If none are present, then the list is expanded with the full set of providers configured in the platform.
 
-The list of states is similarly limited to a known set of possibilities, but no
-further validation is made.
+The list of states is similarly limited to a known set of possibilities, but no further validation is made.
 
 Furthermore, the following are not currently possible:
 
@@ -702,28 +611,18 @@ Furthermore, the following are not currently possible:
 
 * Adding a stack record
 
-Note that making changes to the `hastexo_stack` table does not affect the
-stacks themselves.  In other words, deleting an existing stack here will merely
-delete its database record: not only will the stack itself continue to exist,
-but the XBlock will cease to handle it automatically (such as suspending or
-deleting it) until such time as the learner relaunches it.  The admin page is
-only offered as a convenient way to manually synchronize the database with
-actual stack states in case of failure.  It should not be necessary to do so in
-day-to-day usage of the XBlock.
-
+Note that making changes to the `hastexo_stack` table does not affect the stacks themselves.
+In other words, deleting an existing stack here will merely delete its database record: not only will the stack itself continue to exist, but the XBlock will cease to handle it automatically (such as suspending or deleting it) until such time as the learner relaunches it.
+The admin page is only offered as a convenient way to manually synchronize the database with actual stack states in case of failure.
+It should not be necessary to do so in day-to-day usage of the XBlock.
 
 ## Running tests
 
-The testing framework is built on
-[tox](https://tox.readthedocs.io/). After installing tox, you can
-simply run `tox` from your Git checkout of this repository.
+The testing framework is built on [tox](https://tox.readthedocs.io/).
+After installing tox, you can simply run `tox` from your Git checkout of this repository.
 
-In addition, you can run `tox -r` to throw away and rebuild the
-testing virtualenv, or `tox -e flake8` to run only PEP-8 checks, as
-opposed to the full test suite.
-
+In addition, you can run `tox -r` to throw away and rebuild the testing virtualenv, or `tox -e flake8` to run only PEP-8 checks, as opposed to the full test suite.
 
 ## License
 
-This XBlock is licensed under the Affero GPL; see [`LICENSE`](LICENSE)
-for details.
+This XBlock is licensed under the Affero GPL; see [`LICENSE`](LICENSE) for details.


### PR DESCRIPTION
* Reformat Markdown files to one sentence per line.
* Add syntax highlighting hints to fenced code blocks in `README.md`.
* Fix minor typos in `Changelog.md`.