### PR TITLE
Fix stuck modifier key state after using Cmd+V on Mac

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+-------------------------
+
+* [Bug fix] Fix stuck modifier key state after using Cmd+V paste on Mac.
+
 Version 9.1.0 (2026-05-15)
 -------------------------
 

--- a/stackamole/public/js/client.js
+++ b/stackamole/public/js/client.js
@@ -95,6 +95,13 @@ function StackamoleGuacamoleClient(configuration) {
             shift = false;
         } else if (keysym == 0xFFE3) {
             ctrl = false;
+        } else if (keysym == 0xFFE7 || keysym == 0xFFE8) {
+            cmd = false;
+        }
+
+        // Just return, to release the cmd key, after running a cmd-v on a Mac
+        if (cmd && keysym == 0x0076) { /* cmd-v */
+            return;
         }
 
         /* Delay sending final stroke until clipboard is updated. */


### PR DESCRIPTION
Reset the `cmd` key state correctly after Cmd+V on Mac, preventing inconsistencies with keypress handling.