### PR TITLE
Update README for Libraries V2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+Unreleased
+-------------------------
+
+* [Documentation] Note in README that this XBlock is not supported in Libraries V2 (Ulmo) due to child block limitations.
+
 Version 9.1.1 (2026-05-21)
 -------------------------
 

--- a/README.md
+++ b/README.md
@@ -507,29 +507,8 @@ Edit the Settings as explained above.
 
 ### Using the Stackamole XBlock in a content library
 
-This XBlock is usable in [content libraries](https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/course_components/libraries.html).
-It supports adding lab instructions as child blocks, so that when the block is randomized, the instructions are bundled together with it.
-
-To add the XBlock to the library via Studio, make sure it is configured as one of the `ADVANCED_PROBLEM_TYPES` in `cms.env.json`, then select it as such when adding content to your library.
-(Note: as of Open edX Ironwood, the ability to do so requires running a [patched version](https://github.com/hastexo/edx-platform/tree/hastexo/ironwood/free_the_library) of `edx-platform`.)
-
-The following child block types are currently supported:
-
-  * html
-  * video
-  * [pdf](https://github.com/MarCnu/pdfXBlock)
-
-If using OLX, html blocks can be defined separately in the `html` subdirectory as usual, with the child element referring to it by URL name:
-
-```xml
-<vertical url_name="lab_introduction">
-  <stackamole ...>
-    <html url_name="lab_instructions">
-  </stackamole>
-</vertical>
-```
-
-Child blocks will always be rendered _above_ the terminal.
+Using the Stackamole XBlock in a content library is not supported at this time.
+This is due to the [lack of support for child blocks in Libraries V2 (Ulmo)](https://github.com/openedx/openedx-platform/blob/release/ulmo.3/openedx/core/djangoapps/content_libraries/api/blocks.py#L310-L313).
 
 ### Using the Stackamole XBlock while masquerading as a specific learner
 


### PR DESCRIPTION
The Stackamole XBlock includes child blocks, which is not supported in the current Libraries V2 implementation. Thus, this XBlock cannot be used in Libraries V2 at this time.

Update the README with the current information.