### PR TITLE
Add support for Content Libraries V2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,8 @@
 Unreleased
 -------------------------
 
-* [Documentation] Note in README that this XBlock is not supported in Libraries V2 (Ulmo) due to child block limitations.
+* [Enhancement] Remove child block support to enable compatibility with Content Libraries V2.
+  Library Units now provide a way to combine a Stackamole Lab with other blocks (in a library Unit), making child blocks unnecessary for this purpose.
 
 Version 9.1.1 (2026-05-21)
 -------------------------

--- a/README.md
+++ b/README.md
@@ -507,8 +507,8 @@ Edit the Settings as explained above.
 
 ### Using the Stackamole XBlock in a content library
 
-Using the Stackamole XBlock in a content library is not supported at this time.
-This is due to the [lack of support for child blocks in Libraries V2 (Ulmo)](https://github.com/openedx/openedx-platform/blob/release/ulmo.3/openedx/core/djangoapps/content_libraries/api/blocks.py#L310-L313).
+The Stackamole XBlock supports Content Libraries V2 (Ulmo and later), starting from XBlock version `9.2.0` and Tutor plugin version `3.1.0`.
+Since the Stackamole XBlock no longer supports child blocks, use a separate block (HTML, Markdown) for lab instructions, group it with a Stackamole Lab in a library Unit and add that Unit to your course.
 
 ### Using the Stackamole XBlock while masquerading as a specific learner
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,9 +8,7 @@ lazy<=1.5
 openedx-django-pyfs>=3.8.0
 sqlparse>=0.4.1,<0.5
 web-fragments<=2.0.0
-
-# Other XBlocks that are supported as nested elements
-markdown-xblock
+edx-opaque-keys<=3.0.0
 
 # dependencies of supported nested XBlocks
 path.py>=12.4

--- a/stackamole/stackamole.py
+++ b/stackamole/stackamole.py
@@ -12,8 +12,6 @@ from web_fragments.fragment import Fragment
 from xblock.utils.resources import ResourceLoader
 from xblock.utils.settings import XBlockWithSettingsMixin
 from xblock.utils.studio_editable import (
-    NestedXBlockSpec,
-    StudioContainerWithNestedXBlocksMixin,
     StudioEditableXBlockMixin
 )
 
@@ -26,6 +24,7 @@ from django.utils import timezone, translation
 from lxml import etree
 
 from common.djangoapps.student.models import AnonymousUserId
+from opaque_keys.edx.locator import LibraryUsageLocatorV2
 
 from .models import Stack
 from .common import (
@@ -61,8 +60,7 @@ class LaunchError(Exception):
 class StackamoleXBlock(XBlock,
                        XBlockWithSettingsMixin,
                        ScorableXBlockMixin,
-                       StudioEditableXBlockMixin,
-                       StudioContainerWithNestedXBlocksMixin):
+                       StudioEditableXBlockMixin):
     """
     Provides lab environments and an SSH connection to them.
 
@@ -82,6 +80,7 @@ class StackamoleXBlock(XBlock,
 
     # Mandatory: must be set per instance.
     stack_user_name = String(
+        default="",
         scope=Scope.settings,
         help="The name of the training user in the stack.")
     stack_protocol = String(
@@ -255,7 +254,6 @@ class StackamoleXBlock(XBlock,
 
     has_author_view = True
     has_score = True
-    has_children = True
     icon_class = 'problem'
     block_settings_key = SETTINGS_KEY
     show_in_read_only_mode = True
@@ -373,9 +371,6 @@ class StackamoleXBlock(XBlock,
 
                     else:
                         logger.warning(f"Unknown attribute: {child.tag}")
-            # Import nested blocks
-            for child in node:
-                block.runtime.add_node_as_child(block, child)
 
         else:
             for child in node:
@@ -391,9 +386,6 @@ class StackamoleXBlock(XBlock,
                         block, tag, child.text, child.attrib)
                 elif tag in ['test', 'port', 'provider']:
                     cls.parse_attributes(child.tag, child, block)
-                else:
-                    # Import nested blocks
-                    block.runtime.add_node_as_child(block, child)
 
         # Attributes become fields.
         for name, value in list(node.items()):  # lxml has no iteritems
@@ -430,72 +422,80 @@ class StackamoleXBlock(XBlock,
         For exporting, set data on etree.Element `node`.
         """
 
-        # Write xml data to file
-        pathname = self.url_name.replace(':', '/')
-        filepath = u'{category}/{pathname}.xml'.format(
-            category=self.CATEGORY,
-            pathname=pathname
-        )
+        if self.in_library:
+            root = node
+            root.tag = self.CATEGORY
+        else:
+            # Write xml data to file
+            pathname = self.url_name.replace(':', '/')
+            filepath = u'{category}/{pathname}.xml'.format(
+                category=self.CATEGORY,
+                pathname=pathname
+            )
 
-        self.runtime.export_fs.makedirs(
-            os.path.dirname(filepath),
-            recreate=True)
+            self.runtime.export_fs.makedirs(
+                os.path.dirname(filepath),
+                recreate=True)
 
-        with self.runtime.export_fs.open(filepath, 'wb') as filestream:
+            filestream = self.runtime.export_fs.open(filepath, 'wb')
             root = etree.Element('stackamole')
 
-            if self.hook_events:
-                hook_events_node = etree.SubElement(root, 'hook_events')
-                hook_events_node.set(
-                    'suspend', str(self.hook_events.get("suspend", True)))
-                hook_events_node.set(
-                    'resume', str(self.hook_events.get("resume", True)))
-                hook_events_node.set(
-                    'delete', str(self.hook_events.get("delete", True)))
+        if self.hook_events:
+            hook_events_node = etree.SubElement(root, 'hook_events')
+            hook_events_node.set(
+                'suspend', str(self.hook_events.get("suspend", True)))
+            hook_events_node.set(
+                'resume', str(self.hook_events.get("resume", True)))
+            hook_events_node.set(
+                'delete', str(self.hook_events.get("delete", True)))
 
-            if self.ports:
-                for port in self.ports:
-                    # port must have values for 'name' and 'number',
-                    # raises KeyError if not defined.
-                    port_node = etree.SubElement(root, 'port')
-                    port_node.set('name', port['name'])
-                    port_node.set('number', str(port['number']))
+        if self.ports:
+            for port in self.ports:
+                # port must have values for 'name' and 'number',
+                # raises KeyError if not defined.
+                port_node = etree.SubElement(root, 'port')
+                port_node.set('name', port['name'])
+                port_node.set('number', str(port['number']))
 
-            if self.providers:
-                for provider in self.providers:
-                    provider_node = etree.SubElement(root, 'provider')
-                    # raises KeyError if 'name' is not defined
-                    # one must not add a provider without a name
-                    provider_node.set('name', provider['name'])
-                    capacity = provider.get("capacity", None)
-                    if capacity in (None, "None", ""):
-                        # capacity should not be undefined
-                        # set to -1 (unlimited) in case it is
-                        capacity = -1
-                    provider_node.set('capacity', str(capacity))
-                    # Not having a 'template' or an 'environment' defined for
-                    # a provider is a valid option.
-                    # Only add to node when defined a non-empty value.
-                    template = provider.get("template", None)
-                    if template not in (None, "None"):
-                        provider_node.set('template', template)
-                    environment = provider.get("environment", None)
-                    if environment not in (None, "None"):
-                        provider_node.set('environment', environment)
+        if self.providers:
+            for provider in self.providers:
+                provider_node = etree.SubElement(root, 'provider')
+                # raises KeyError if 'name' is not defined
+                # one must not add a provider without a name
+                provider_node.set('name', provider['name'])
+                capacity = provider.get("capacity", None)
+                if capacity in (None, "None", ""):
+                    # capacity should not be undefined
+                    # set to -1 (unlimited) in case it is
+                    capacity = -1
+                provider_node.set('capacity', str(capacity))
+                # Not having a 'template' or an 'environment' defined for
+                # a provider is a valid option.
+                # Only add to node when defined a non-empty value.
+                template = provider.get("template", None)
+                if template not in (None, "None"):
+                    provider_node.set('template', template)
+                environment = provider.get("environment", None)
+                if environment not in (None, "None"):
+                    provider_node.set('environment', environment)
 
-            if self.tests:
-                for test in self.tests:
-                    etree.SubElement(
-                        root, 'test').text = etree.CDATA(test)
+        if self.tests:
+            for test in self.tests:
+                etree.SubElement(
+                    root, 'test').text = etree.CDATA(test)
+
+        if not self.in_library:
             etree.ElementTree(
                 root).write(filestream, pretty_print=True, encoding='utf-8')
+            filestream.close()
+            # Write out the xml file name
+            filename = os.path.basename(pathname)
+            node.tag = self.CATEGORY
+            node.set('filename', filename)
 
-        # Write out the xml file name
-        filename = os.path.basename(pathname)
+            self._set_module_name()
 
         # Add all editable fields as node attributes
-        node.tag = self.CATEGORY
-        node.set("filename", filename)
         node.set('xblock-family', self.entry_point)
         node.set('display_name', self.display_name)
         node.set('progress_check_label', self.progress_check_label)
@@ -516,49 +516,10 @@ class StackamoleXBlock(XBlock,
         node.set('hidden', str(self.hidden))
         node.set('enable_fullscreen', self.enable_fullscreen)
 
-        # Include nested blocks in course export
-        if self.has_children:
-            for child_id in self.children:
-                child = self.runtime.get_block(child_id)
-                self.runtime.add_block_as_child_node(child, node)
-
-        self._set_module_name()
-
     @property
-    def allowed_nested_blocks(self):
-        """
-        Returns a list of allowed nested blocks.
-
-        """
-        additional_blocks = []
-        try:
-            from xmodule.video_module.video_module import VideoBlock
-            _spec = NestedXBlockSpec(
-                VideoBlock, category="video", label=u"Video"
-            )
-            additional_blocks.append(_spec)
-        except ImportError:
-            logger.warning("Unable to import VideoBlock", exc_info=True)
-
-        try:
-            from pdf import pdfXBlock
-            _spec = NestedXBlockSpec(pdfXBlock, category="pdf", label=u"PDF")
-            additional_blocks.append(_spec)
-        except ImportError:
-            logger.info("Unable to import pdfXblock", exc_info=True)
-
-        try:
-            from markdown_xblock import MarkdownXBlock
-            _spec = NestedXBlockSpec(MarkdownXBlock,
-                                     category="markdown",
-                                     label=u"Markdown")
-            additional_blocks.append(_spec)
-        except ImportError:
-            logger.info("Unable to import MarkdownXBlock", exc_info=True)
-
-        return [
-            NestedXBlockSpec(None, category="html", label=u"HTML")
-        ] + additional_blocks
+    def in_library(self):
+        # Check if we are in the library context
+        return isinstance(self.scope_ids.usage_id, LibraryUsageLocatorV2)
 
     def is_correct(self):
         if self.score:
@@ -732,6 +693,11 @@ class StackamoleXBlock(XBlock,
         The primary view of the StackamoleXBlock, shown to students when
         viewing courses.
         """
+        # Library will call the student view, don't try to launch a lab,
+        # return the author view instead.
+        if self.in_library:
+            return self.author_view()
+
         # Load configuration
         settings = get_xblock_settings()
 
@@ -745,21 +711,12 @@ class StackamoleXBlock(XBlock,
 
         frag = Fragment()
 
-        # Render children
-        child_content = ""
-        for child_id in self.children:
-            child = self.runtime.get_block(child_id)
-            child_fragment = child.render("student_view", context)
-            frag.add_fragment_resources(child_fragment)
-            child_content += child_fragment.content
-
         # Render the main template
         i18n_service = self.runtime.service(self, "i18n")
 
         frag.add_content(loader.render_django_template(
             "static/html/main.html",
-            {"child_content": child_content,
-             "enable_fullscreen": enable_fullscreen},
+            {"enable_fullscreen": enable_fullscreen},
             i18n_service=i18n_service
         ))
 
@@ -781,6 +738,13 @@ class StackamoleXBlock(XBlock,
         frag.initialize_js('StackamoleXBlock', context)
 
         return frag
+
+    def author_view(self, context=None):
+        """
+        The author view of the StackamoleXBlock, return an empty Fragment
+        when used in Studio and/or in a Library.
+        """
+        return Fragment()
 
     @transaction.atomic
     def create_stack(self, settings, course_id, student_id):

--- a/tests/unit/test_stackamole.py
+++ b/tests/unit/test_stackamole.py
@@ -15,18 +15,16 @@ from stackamole.common import (
 from common.djangoapps.student.models import AnonymousUserId
 from fs.osfs import OSFS
 from lxml import etree
-from markdown_xblock import MarkdownXBlock
 from unittest.mock import Mock, patch, DEFAULT
 from webob import Request
 from django.contrib.auth.models import User
 from django.test import TestCase
 from workbench.runtime import WorkbenchRuntime
-from xblock.core import XBlock
 from xblock.fields import ScopeIds
 from xblock.runtime import KvsFieldData, DictKeyValueStore
 from xblock.scorable import Score
 from xblock.test.test_parsing import XmlTest
-from sample_xblocks.basic.content import HtmlBlock
+from opaque_keys.edx.locator import LibraryUsageLocatorV2
 
 
 def make_request(data, method='POST'):
@@ -197,21 +195,14 @@ class TestStackamoleXBlockParsing(XmlTest, TestCase):
         self.assertEqual(block.tests[0], "Multi-line\ntest 1\n")
         self.assertEqual(block.tests[1], "Multi-line\ntest 2\n")
 
-    @XBlock.register_temp_plugin(HtmlBlock, "html")
     def test_student_view(self):
         block = self.parse_xml_to_block(textwrap.dedent("""\
     <?xml version='1.0' encoding='utf-8'?>
     <stackamole xmlns:option="http://code.edx.org/xblock/option"
-      stack_template_path='hot_lab.yaml'
-      stack_user_name='training'
-      stack_protocol='rdp'
-      launch_timeout='900'>
-      <html>
-        This is a child.
-      </html>
-      <html>
-        This is another child.
-      </html>
+    stack_template_path='hot_lab.yaml'
+    stack_user_name='training'
+    stack_protocol='rdp'
+    launch_timeout='900'>
     </stackamole>
             """).encode('utf-8'))
 
@@ -227,53 +218,28 @@ class TestStackamoleXBlockParsing(XmlTest, TestCase):
                 create_stack=mock_create_stack):
 
             frag = block.student_view({})
-            html = frag.body_html()
+            self.assertNotEqual(frag.content, "")
 
-        self.assertIn("This is a child.", html)
-        self.assertIn("This is another child.", html)
-
-    @XBlock.register_temp_plugin(HtmlBlock, "html")
-    def test_nested_blocks_spec(self):
-        """A nested html element should be supported."""
+    def test_author_view(self):
         block = self.parse_xml_to_block(textwrap.dedent("""\
     <?xml version='1.0' encoding='utf-8'?>
     <stackamole xmlns:option="http://code.edx.org/xblock/option"
-      stack_template_path='hot_lab.yaml'
-      stack_user_name='training'
-      stack_protocol='rdp'
-      launch_timeout='900'>
-      <html>
-        This is a child.
-      </html>
+    stack_template_path='hot_lab.yaml'
+    stack_user_name='training'
+    stack_protocol='rdp'
+    launch_timeout='900'>
     </stackamole>
             """).encode('utf-8'))
+        block.scope_ids = block.scope_ids._replace(
+            usage_id=LibraryUsageLocatorV2.from_string(
+                "lb:org:lib:stackamole:test"))
 
-        specs = block.get_nested_blocks_spec()
-        self.assertEqual(len(specs), 2)
-
-    def test_parsing_nested_markdown_xblock(self):
-        """A nested markdown element should be supported."""
-
-        with patch('markdown_xblock.html.MarkdownXBlock.parse_xml') as p:
-            p.return_value = Mock()
-
-            block = self.parse_xml_to_block(textwrap.dedent("""\
-        <?xml version='1.0' encoding='utf-8'?>
-        <stackamole xmlns:option="http://code.edx.org/xblock/option"
-            stack_template_path='hot_lab.yaml'
-            stack_user_name='training'
-            stack_protocol='rdp'
-            launch_timeout='900'>
-            <markdown/>
-        </stackamole>
-                """).encode('utf-8'))
-
-            self.assertTrue(p.called)
-            self.assertTrue(block.has_children)
-            nested_blocks = block.get_children()
-
-            self.assertEqual(len(nested_blocks), 1)
-            self.assertEqual(nested_blocks[0].display_name, 'Markdown')
+        frag1 = block.student_view({})
+        frag2 = block.author_view({})
+        # in a library context, student view will return the author view
+        self.assertEqual(frag1.content, frag2.content)
+        # author view returns an empty fragment
+        self.assertEqual(frag2.content, "")
 
 
 class TestStackamoleXBlock(TestCase):
@@ -1157,43 +1123,28 @@ class TestStackamoleXBlock(TestCase):
         export_fs.remove('stackamole/fake_lab.xml')
         export_fs.removedir('stackamole')
 
-    def test_export_nested_xblock(self):
-        # set up a markdown xblock
-        markdown_xblock = MarkdownXBlock(
-            self.block.runtime,
-            scope_ids=(ScopeIds('user', 'markdown', '.markdown.d0',
-                                '.markdown.d0.u0')))
-        markdown_xblock.url_name = 'fake_lab_instructions'
-        markdown_xblock.category = 'markdown'
-
+    def test_libary_save(self):
         # setup
         self.init_block()
-        self.block.children.append(markdown_xblock)
         self.block.url_name = 'fake_lab'
         self.block.category = 'stackamole'
-        export_fs = OSFS('fake/course')
-        self.block.runtime.export_fs = export_fs
-        self.block.runtime.get_block = Mock()
-        self.block.runtime.get_block.return_value = markdown_xblock
-        self.block.runtime.add_block_as_child_node = Mock()
+        self.block.scope_ids = self.block.scope_ids._replace(
+            usage_id=LibraryUsageLocatorV2.from_string(
+                "lb:org:lib:stackamole:test"))
 
         # create an empty node
         node = etree.Element('unknown')
 
+        # assert that the node is empty, with a tag 'unknown'
+        self.assertEqual(node.items(), [])
+        self.assertEqual(node.tag, 'unknown')
+
         # run the export
         self.block.add_xml_to_node(node)
 
-        # assert get_block and add_block_as_child_node were called
-        self.block.runtime.get_block.assert_called_once_with(markdown_xblock)
-        self.block.runtime.add_block_as_child_node.assert_called_once_with(
-            markdown_xblock, node)
-
-        # assert that the exported file exists
-        self.assertTrue(export_fs.exists('stackamole/fake_lab.xml'))
-
-        # clean up
-        export_fs.remove('stackamole/fake_lab.xml')
-        export_fs.removedir('stackamole')
+        # assert that the node now contains the xblock information
+        self.assertNotEqual(node.items(), [])
+        self.assertEqual(node.tag, 'stackamole')
 
     def test_parse_xblock_from_separate_file(self):
         block_type = 'stackamole'


### PR DESCRIPTION
* Remove child block support to enable compatibility with Content
  Libraries V2.
* Add context checks to handle a course export vs saving a block in
  the library.
* Add context checks to handle library and LMS views.