### PR TITLE
fix: Set absolute URL for .agents/skills submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".agents/skills"]
 	path = .agents/skills
-	url = ../skills
+	url = https://github.com/cleura/skills


### PR DESCRIPTION
The `uv` version that Tutor uses for image builds (at the time of writing, 0.9.18) breaks with submodules using relative paths. Until Tutor upgrades to `uv` version 0.11.15 or later, use an absolute URL instead.

References:
https://github.com/overhangio/tutor/blob/v21.0.7/tutor/templates/build/openedx/Dockerfile#L14
https://github.com/astral-sh/uv/issues/9822
https://github.com/astral-sh/uv/pull/1215