### PR TITLE
chore: Drop Google-related dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "apscheduler<4",
     "cliff<=4.7",
     "dogpile.cache<=1.3",
-    "google-api-python-client<=2.167.0",
     "keystoneauth1<=5.8",
     "openstacksdk<=4.1",
     "osc-lib<=3.1",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,8 +1,6 @@
 apscheduler<4
 cliff<=4.7
 dogpile.cache<=1.3
-google-auth<=2.47.0 # keep in sync with edx-platform
-google-api-python-client<=2.167.0 # keep in sync with edx-platform
 keystoneauth1<=5.8
 openstacksdk<=4.1
 osc-lib<=3.1


### PR DESCRIPTION
We dropped support for the GCloud provider in a3d5371df22140571b3f7bfd213a00540c1e9cc1.

While other parts of Open edX might still require Google-related libraries (and they may thus be installed in an Open edX image alongside the XBlock), there is really no longer any need to track these dependencies from this XBlock.

Thus, drop them from `pyproject.toml` and `requirements.txt`.
